### PR TITLE
S3 support and better video convertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 - make wiki and forums optional
 - use zimscraperlib for downloading and optimizing videos
 - refactored Dockerfile
+- add s3 based optimization cache

--- a/openedx2zim/annex.py
+++ b/openedx2zim/annex.py
@@ -177,7 +177,7 @@ def forum(c, scraper):
                 forum_output.joinpath(thread["id"]),
                 "",
                 c,
-                scarper,
+                scraper,
             )
             if "children" in children:
                 for children_children in children["children"]:

--- a/openedx2zim/annex.py
+++ b/openedx2zim/annex.py
@@ -18,7 +18,9 @@ logger = getLogger()
 def forum(c, scraper):
     forum_output = scraper.build_dir.joinpath("forum")
     forum_output.mkdir(parents=True, exist_ok=True)
-    content = c.get_page(scraper.instance_url + "/courses/" + scraper.course_id + "/discussion/forum")
+    content = c.get_page(
+        scraper.instance_url + "/courses/" + scraper.course_id + "/discussion/forum"
+    )
     good_content = BeautifulSoup(content, "lxml").find(
         "script", attrs={"id": "thread-list-template"}
     )
@@ -171,7 +173,11 @@ def forum(c, scraper):
         )
         for children in thread["data_thread"]["content"]["children"]:
             children["body"] = dl_dependencies(
-                markdown(children["body"]), forum_output.joinpath(thread["id"]), "", c, scarper,
+                markdown(children["body"]),
+                forum_output.joinpath(thread["id"]),
+                "",
+                c,
+                scarper,
             )
             if "children" in children:
                 for children_children in children["children"]:
@@ -364,7 +370,10 @@ def booknav(scraper, book, output_path):
     book_list = []
     for url in pdf:
         file_name = pathlib.Path(urllib.parse.urlparse(url["rel"][0]).path).name
-        scraper.download_file(prepare_url(url["rel"][0], scraper.instance_url), output_path.joinpath(file_name))
+        scraper.download_file(
+            prepare_url(url["rel"][0], scraper.instance_url),
+            output_path.joinpath(file_name),
+        )
         book_list.append({"url": file_name, "name": url.get_text()})
     return book_list
 

--- a/openedx2zim/constants.py
+++ b/openedx2zim/constants.py
@@ -23,6 +23,9 @@ IMAGE_FORMATS = ["png", "jpeg", "jpg", "gif"]
 OPTIMIZER_VERSIONS = {
     "mp4": f"v{VideoMp4Low().VERSION}",
     "webm": f"v{VideoWebmLow().VERSION}",
+    "png": "v1",
+    "jpeg": "v1",
+    "gif": "v1",
 }
 
 
@@ -38,36 +41,3 @@ def setDebug(debug):
 def getLogger():
     """ configured logger respecting DEBUG flag """
     return lib_getLogger(NAME, level=logging.DEBUG if Global.debug else logging.INFO)
-
-
-from .xblocks_extractor.Course import Course
-from .xblocks_extractor.Chapter import Chapter
-from .xblocks_extractor.Sequential import Sequential
-from .xblocks_extractor.Vertical import Vertical
-from .xblocks_extractor.Video import Video
-from .xblocks_extractor.Libcast import Libcast
-from .xblocks_extractor.Html import Html
-from .xblocks_extractor.Problem import Problem
-from .xblocks_extractor.Discussion import Discussion
-from .xblocks_extractor.FreeTextResponse import FreeTextResponse
-from .xblocks_extractor.Unavailable import Unavailable
-from .xblocks_extractor.Lti import Lti
-from .xblocks_extractor.DragAndDropV2 import DragAndDropV2
-
-XBLOCK_EXTRACTORS = {
-    "course": Course,
-    "chapter": Chapter,
-    "sequential": Sequential,
-    "vertical": Vertical,
-    "video": Video,
-    "libcast_xblock": Libcast,
-    "html": Html,
-    "problem": Problem,
-    "discussion": Discussion,
-    "qualtricssurvey": Html,
-    "freetextresponse": FreeTextResponse,
-    "grademebutton": Unavailable,
-    "drag-and-drop-v2": DragAndDropV2,
-    "lti": Lti,
-    "unavailable": Unavailable,
-}

--- a/openedx2zim/constants.py
+++ b/openedx2zim/constants.py
@@ -20,7 +20,10 @@ VIDEO_FORMATS = ["webm", "mp4"]
 
 IMAGE_FORMATS = ["png", "jpeg", "jpg", "gif"]
 
-OPTIMIZER_VERSIONS = {"mp4": f"v{VideoMp4Low().VERSION}", "webm": f"v{VideoWebmLow().VERSION}"}
+OPTIMIZER_VERSIONS = {
+    "mp4": f"v{VideoMp4Low().VERSION}",
+    "webm": f"v{VideoWebmLow().VERSION}",
+}
 
 
 class Global:

--- a/openedx2zim/constants.py
+++ b/openedx2zim/constants.py
@@ -6,6 +6,7 @@ import pathlib
 import logging
 
 from zimscraperlib.logging import getLogger as lib_getLogger
+from zimscraperlib.video.presets import VideoMp4Low, VideoWebmLow
 
 ROOT_DIR = pathlib.Path(__file__).parent
 NAME = ROOT_DIR.name
@@ -14,6 +15,12 @@ with open(ROOT_DIR.joinpath("VERSION"), "r") as fh:
     VERSION = fh.read().strip()
 
 SCRAPER = f"{NAME} {VERSION}"
+
+VIDEO_FORMATS = ["webm", "mp4"]
+
+IMAGE_FORMATS = ["png", "jpeg", "jpg", "gif"]
+
+OPTIMIZER_VERSIONS = {"mp4": f"v{VideoMp4Low().VERSION}", "webm": f"v{VideoWebmLow().VERSION}"}
 
 
 class Global:

--- a/openedx2zim/entrypoint.py
+++ b/openedx2zim/entrypoint.py
@@ -28,6 +28,28 @@ def main():
     )
 
     parser.add_argument(
+        "--format",
+        help="Format to download/transcode video to. webm is smaller",
+        choices=["mp4", "webm"],
+        default="webm",
+        dest="video_format",
+    )
+
+    parser.add_argument(
+        "--low-quality",
+        help="Re-encode video using stronger compression",
+        action="store_true",
+        default=False,
+    )
+
+    parser.add_argument(
+        "--autoplay",
+        help="Enable autoplay on video articles. Behavior differs on platforms/browsers.",
+        action="store_true",
+        default=False,
+    )
+
+    parser.add_argument(
         "--name",
         help="ZIM name. Used as identifier and filename (date will be appended)",
         required=True,
@@ -54,13 +76,6 @@ def main():
     )
 
     parser.add_argument(
-        "--convert-in-webm",
-        help="Re-encode videos to WebM",
-        action="store_true",
-        default=False,
-    )
-
-    parser.add_argument(
         "--ignore-missing-xblocks",
         help="Ignore unsupported content (xblock)",
         action="store_true",
@@ -84,6 +99,19 @@ def main():
         help="Add forum (if available) to the ZIM",
         action="store_true",
         default=False,
+    )
+
+    parser.add_argument(
+        "--optimization-cache",
+        help="URL with credentials and bucket name to S3 Optimization Cache",
+        dest="s3_url_with_credentials",
+    )
+
+    parser.add_argument(
+        "--use-any-optimized-version",
+        help="Use files on S3 cache if present, whatever the version",
+        default=False,
+        action="store_true",
     )
 
     parser.add_argument(

--- a/openedx2zim/entrypoint.py
+++ b/openedx2zim/entrypoint.py
@@ -43,13 +43,6 @@ def main():
     )
 
     parser.add_argument(
-        "--autoplay",
-        help="Enable autoplay on video articles. Behavior differs on platforms/browsers.",
-        action="store_true",
-        default=False,
-    )
-
-    parser.add_argument(
         "--name",
         help="ZIM name. Used as identifier and filename (date will be appended)",
         required=True,

--- a/openedx2zim/scraper.py
+++ b/openedx2zim/scraper.py
@@ -283,9 +283,7 @@ class Openedx2Zim:
                         self.forum_thread,
                         self.forum_category,
                         self.staff_user_forum,
-                    ) = forum(
-                        connection, self
-                    )
+                    ) = forum(connection, self)
                 elif ("wiki" not in tab_path) and ("forum" not in tab_path):
                     output_path = self.build_dir.joinpath(tab_path)
                     output_path.mkdir(parents=True, exist_ok=True)
@@ -488,7 +486,6 @@ class Openedx2Zim:
         except Exception as exc:
             logger.error(f"Error while running youtube_dl: {exc}")
             return None
-        
 
     def convert_video(self, src, dst):
         if (src.suffix[1:] != self.video_format) or self.low_quality:
@@ -555,6 +552,9 @@ class Openedx2Zim:
                 else:
                     if self.s3_storage:
                         self.upload_to_cache(s3_key, fpath, meta)
+            else:
+                if not downloaded_file.resolve() == fpath.resolve():
+                    shutil.move(downloaded_file, fpath)
 
     def render(self):
         # Render course

--- a/openedx2zim/utils.py
+++ b/openedx2zim/utils.py
@@ -192,7 +192,9 @@ def dl_dependencies(content, path, folder_name, c, scraper):
             # download the image only if it's not already downloaded
             if not os.path.exists(out):
                 try:
-                    scraper.download_file(prepare_url(src, c.conf["instance_url"]), pathlib.Path(out))
+                    scraper.download_file(
+                        prepare_url(src, c.conf["instance_url"]), pathlib.Path(out)
+                    )
                 except Exception as e:
                     logger.warning(str(e) + " : error with " + src)
                     pass
@@ -234,7 +236,10 @@ def dl_dependencies(content, path, folder_name, c, scraper):
                 not is_absolute(src) and not "wiki" in src
             ):  # Download when ext match, or when link is relatif (but not in wiki, because links in wiki are relatif)
                 if not os.path.exists(out):
-                    scraper.download_file(prepare_url(unquote(src), c.conf["instance_url"]), pathlib.Path(out))
+                    scraper.download_file(
+                        prepare_url(unquote(src), c.conf["instance_url"]),
+                        pathlib.Path(out),
+                    )
                 src = os.path.join(folder_name, filename)
                 a.attrib["href"] = src
     csss = body.xpath("//link")
@@ -245,7 +250,9 @@ def dl_dependencies(content, path, folder_name, c, scraper):
             filename = sha256(str(src).encode("utf-8")).hexdigest() + ext
             out = os.path.join(path, filename)
             if not os.path.exists(out):
-                scraper.download_file(prepare_url(src, c.conf["instance_url"]), pathlib.Path(out))
+                scraper.download_file(
+                    prepare_url(src, c.conf["instance_url"]), pathlib.Path(out)
+                )
             src = os.path.join(folder_name, filename)
             css.attrib["href"] = src
     jss = body.xpath("//script")
@@ -256,7 +263,9 @@ def dl_dependencies(content, path, folder_name, c, scraper):
             filename = sha256(str(src).encode("utf-8")).hexdigest() + ext
             out = os.path.join(path, filename)
             if not os.path.exists(out):
-                scraper.download_file(prepare_url(src, c.conf["instance_url"]), pathlib.Path(out))
+                scraper.download_file(
+                    prepare_url(src, c.conf["instance_url"]), pathlib.Path(out)
+                )
             src = os.path.join(folder_name, filename)
             js.attrib["src"] = src
     sources = body.xpath("//source")
@@ -267,7 +276,9 @@ def dl_dependencies(content, path, folder_name, c, scraper):
             filename = sha256(str(src).encode("utf-8")).hexdigest() + ext
             out = os.path.join(path, filename)
             if not os.path.exists(out):
-                scraper.download_file(prepare_url(src, c.conf["instance_url"]), pathlib.Path(out))
+                scraper.download_file(
+                    prepare_url(src, c.conf["instance_url"]), pathlib.Path(out)
+                )
             src = os.path.join(folder_name, filename)
             source.attrib["src"] = src
     iframes = body.xpath("//iframe")
@@ -295,7 +306,10 @@ def dl_dependencies(content, path, folder_name, c, scraper):
                 filename = sha256(str(src).encode("utf-8")).hexdigest() + ext
                 out = os.path.join(path, filename)
                 if not os.path.exists(out):
-                    scraper.download_file(prepare_url(unquote(src), c.conf["instance_url"]), pathlib.Path(out))
+                    scraper.download_file(
+                        prepare_url(unquote(src), c.conf["instance_url"]),
+                        pathlib.Path(out),
+                    )
                 src = os.path.join(folder_name, filename)
                 iframe.attrib["src"] = src
     if imgs or docs or csss or jss or sources or iframes:

--- a/openedx2zim/utils.py
+++ b/openedx2zim/utils.py
@@ -336,17 +336,15 @@ def get_meta_from_url(url):
         response_headers = get_response_headers(url)
     except Exception as exc:
         logger.error(f"{url} > Problem with head request\n{exc}\n")
-        return None, None, None
+        return None, None
     else:
         content_type = mimetypes.guess_extension(
-            response_headers.get("content-type", None).partition(";")[0].strip()
+            response_headers.get("content-type", None).split(";", 1)[0].strip()
         )[1:]
-        if content_type:
-            content_type = content_type.split("/")[-1]
         if response_headers.get("etag", None) is not None:
-            return "etag", response_headers["etag"], content_type
+            return response_headers["etag"], content_type
         if response_headers.get("last-modified", None) is not None:
-            return "last-modified", response_headers["last-modified"], content_type
+            return response_headers["last-modified"], content_type
         if response_headers.get("content-length", None) is not None:
-            return "content-length", response_headers["content-length"], content_type
-    return None, None, content_type
+            return response_headers["content-length"], content_type
+    return None, content_type

--- a/openedx2zim/utils.py
+++ b/openedx2zim/utils.py
@@ -358,11 +358,32 @@ def dl_dependencies(content, path, folder_name, c):
         content = html2string(body, encoding="unicode")
     return content
 
-
-def make_dir(path):
-    if not os.path.exists(path):
-        os.makedirs(path)
-
-
 def first_word(text):
     return " ".join(text.split(" ")[0:5])
+
+def get_meta_from_url(url):
+    def get_response_headers(url):
+        for attempt in range(5):
+            try:
+                return requests.head(url=url, allow_redirects=True, timeout=30).headers
+            except requests.exceptions.Timeout:
+                print(f"{url} > HEAD request timed out ({attempt})")
+        raise Exception("Max retries exceeded")
+    try:
+        response_headers = get_response_headers(url)
+    except Exception as exc:
+        print(f"{url} > Problem with head request\n{exc}\n")
+        return None
+    else:
+        filetype = response_headers.get("content-type", None)
+        if filetype:
+            filetype = filetype.split("/")[-1]
+        if response_headers.get("etag", None) is not None:
+            return {"etag": response_headers["etag"]}, filetype
+        if response_headers.get("last-modified", None) is not None:
+            return {"last-modified": response_headers["last-modified"]}, filetype
+        if response_headers.get("content-length", None) is not None:
+            return {"content-length": response_headers["content-length"]}, filetype
+    return {"default", "default"}, filetype
+
+def is_optimizable()

--- a/openedx2zim/utils.py
+++ b/openedx2zim/utils.py
@@ -3,7 +3,6 @@ import shlex
 import os
 import pathlib
 import datetime
-import logging
 from jinja2 import Environment
 from jinja2 import FileSystemLoader
 from slugify import slugify
@@ -28,6 +27,9 @@ import magic
 import requests
 from zimscraperlib.video.encoding import reencode
 from zimscraperlib.video.presets import VideoWebmLow
+from .constants import getLogger, VIDEO_FORMATS, IMAGE_FORMATS
+
+logger = getLogger()
 
 renderer = mistune.HTMLRenderer()
 MARKDOWN = mistune.Markdown(renderer)
@@ -41,7 +43,7 @@ def exec_cmd(cmd, timeout=None):
     try:
         return subprocess.call(shlex.split(cmd), timeout=timeout)
     except Exception as e:
-        logging.error(e)
+        logger.error(e)
         pass
 
 
@@ -92,16 +94,6 @@ def prepare_url(url, instance_url):
     return urllib.parse.urlunsplit(split_url)
 
 
-def download(url, output, instance_url):
-    url = prepare_url(url, instance_url)
-    try:
-        save_large_file(url, output)
-        return True
-    except subprocess.CalledProcessError as e:
-        logging.error(f"Download failed for {url} - {e}")
-        return False
-
-
 def download_and_convert_subtitles(path, lang_and_url, c):
     real_subtitles = {}
     for lang in lang_and_url:
@@ -119,12 +111,12 @@ def download_and_convert_subtitles(path, lang_and_url, c):
                 real_subtitles[lang] = lang + ".vtt"
             except HTTPError as e:
                 if e.code == 404 or e.code == 403:
-                    logging.error(
+                    logger.error(
                         "Fail to get subtitle from {}".format(lang_and_url[lang])
                     )
                     pass
             except Exception as e:
-                logging.error(
+                logger.error(
                     "Error when converting subtitle {} : {}".format(
                         lang_and_url[lang], e
                     )
@@ -142,26 +134,6 @@ def is_webvtt(path):
     return "WEBVTT" in first_line or "webvtt" in first_line
 
 
-def download_youtube(youtube_url, video_path):
-    parametre = {"outtmpl": video_path, "preferredcodec": "mp4", "format": "mp4"}
-    with youtube_dl.YoutubeDL(parametre) as ydl:
-        ydl.download([youtube_url])
-
-
-def convert_video_to_webm(video_path, video_final_path):
-    logging.info("convert " + video_path + "to webm")
-    try:
-        reencode(
-            pathlib.Path(video_path),
-            pathlib.Path(video_final_path),
-            VideoWebmLow().to_ffmpeg_args(),
-            delete_src=True,
-            failsafe=False,
-        )
-    except Exception as exc:
-        logging.error(f"{video_path} - Error while converting to WebM\n {exc}")
-
-
 def get_filetype(headers, path):
     extensions = ("png", "jpeg", "gif")
     content_type = headers.get("content-type", "").lower().strip()
@@ -175,21 +147,6 @@ def get_filetype(headers, path):
         if ext.upper() in mime:
             return ext
     return "none"
-
-
-def optimize_one(path, type):
-    if type == "jpeg":
-        exec_cmd("jpegoptim --strip-all -m50 " + path, timeout=10)
-    elif type == "png":
-        exec_cmd("pngquant --verbose --nofs --force --ext=.png " + path, timeout=10)
-        exec_cmd("advdef -q -z -4 -i 5  " + path, timeout=10)
-    elif type == "gif":
-        exec_cmd("gifsicle --batch -O3 -i " + path, timeout=10)
-
-
-def resize_one(path, type, nb_pix):
-    if type in ["gif", "png", "jpeg"]:
-        exec_cmd("mogrify -resize " + nb_pix + "x\> " + path, timeout=10)
 
 
 def jinja(output, template, deflate, **context):
@@ -223,17 +180,7 @@ def clean_top(t):
     return "/".join(t.split("/")[:-1])
 
 
-def get_headers(url, instance_url):
-    url = prepare_url(url, instance_url)
-    for attempt in range(5):
-        try:
-            return requests.head(url=url, allow_redirects=True, timeout=30).headers
-        except requests.exceptions.Timeout:
-            print(f"{url} > HEAD request timed out ({attempt})")
-    raise Exception("Max retries exceeded")
-
-
-def dl_dependencies(content, path, folder_name, c):
+def dl_dependencies(content, path, folder_name, c, scraper):
     body = string2html(str(content))
     imgs = body.xpath("//img")
     for img in imgs:
@@ -245,12 +192,9 @@ def dl_dependencies(content, path, folder_name, c):
             # download the image only if it's not already downloaded
             if not os.path.exists(out):
                 try:
-                    headers = get_headers(src, c.conf["instance_url"])
-                    download(src, out, c.conf["instance_url"])
-                    type_of_file = get_filetype(headers, out)
-                    optimize_one(out, type_of_file)
+                    scraper.download_file(prepare_url(src, c.conf["instance_url"]), pathlib.Path(out))
                 except Exception as e:
-                    logging.warning(str(e) + " : error with " + src)
+                    logger.warning(str(e) + " : error with " + src)
                     pass
             src = os.path.join(folder_name, filename)
             img.attrib["src"] = src
@@ -290,7 +234,7 @@ def dl_dependencies(content, path, folder_name, c):
                 not is_absolute(src) and not "wiki" in src
             ):  # Download when ext match, or when link is relatif (but not in wiki, because links in wiki are relatif)
                 if not os.path.exists(out):
-                    download(unquote(src), out, c.conf["instance_url"])
+                    scraper.download_file(prepare_url(unquote(src), c.conf["instance_url"]), pathlib.Path(out))
                 src = os.path.join(folder_name, filename)
                 a.attrib["href"] = src
     csss = body.xpath("//link")
@@ -301,7 +245,7 @@ def dl_dependencies(content, path, folder_name, c):
             filename = sha256(str(src).encode("utf-8")).hexdigest() + ext
             out = os.path.join(path, filename)
             if not os.path.exists(out):
-                download(src, out, c.conf["instance_url"])
+                scraper.download_file(prepare_url(src, c.conf["instance_url"]), pathlib.Path(out))
             src = os.path.join(folder_name, filename)
             css.attrib["href"] = src
     jss = body.xpath("//script")
@@ -312,7 +256,7 @@ def dl_dependencies(content, path, folder_name, c):
             filename = sha256(str(src).encode("utf-8")).hexdigest() + ext
             out = os.path.join(path, filename)
             if not os.path.exists(out):
-                download(src, out, c.conf["instance_url"])
+                scraper.download_file(prepare_url(src, c.conf["instance_url"]), pathlib.Path(out))
             src = os.path.join(folder_name, filename)
             js.attrib["src"] = src
     sources = body.xpath("//source")
@@ -323,7 +267,7 @@ def dl_dependencies(content, path, folder_name, c):
             filename = sha256(str(src).encode("utf-8")).hexdigest() + ext
             out = os.path.join(path, filename)
             if not os.path.exists(out):
-                download(src, out, c.conf["instance_url"])
+                scraper.download_file(prepare_url(src, c.conf["instance_url"]), pathlib.Path(out))
             src = os.path.join(folder_name, filename)
             source.attrib["src"] = src
     iframes = body.xpath("//iframe")
@@ -333,13 +277,13 @@ def dl_dependencies(content, path, folder_name, c):
             if "youtube" in src:
                 name = src.split("/")[-1]
                 out_dir = os.path.join(path, name)
-                make_dir(out_dir)
+                pathlib.Path(out_dir).mkdir(parents=True, exist_ok=True)
                 out = os.path.join(out_dir, "video.mp4")
                 if not os.path.exists(out):
                     try:
-                        download_youtube(src, out)
+                        scraper.download_file(src, pathlib.Path(out))
                     except Exception as e:
-                        logging.warning(str(e) + " : error with " + src)
+                        logger.warning(str(e) + " : error with " + src)
                         pass
                 x = jinja(
                     None, "video.html", False, format="mp4", folder_name=name, subs=[]
@@ -351,15 +295,17 @@ def dl_dependencies(content, path, folder_name, c):
                 filename = sha256(str(src).encode("utf-8")).hexdigest() + ext
                 out = os.path.join(path, filename)
                 if not os.path.exists(out):
-                    download(unquote(src), out, c.conf["instance_url"])
+                    scraper.download_file(prepare_url(unquote(src), c.conf["instance_url"]), pathlib.Path(out))
                 src = os.path.join(folder_name, filename)
                 iframe.attrib["src"] = src
     if imgs or docs or csss or jss or sources or iframes:
         content = html2string(body, encoding="unicode")
     return content
 
+
 def first_word(text):
     return " ".join(text.split(" ")[0:5])
+
 
 def get_meta_from_url(url):
     def get_response_headers(url):
@@ -367,13 +313,14 @@ def get_meta_from_url(url):
             try:
                 return requests.head(url=url, allow_redirects=True, timeout=30).headers
             except requests.exceptions.Timeout:
-                print(f"{url} > HEAD request timed out ({attempt})")
+                logger.error(f"{url} > HEAD request timed out ({attempt})")
         raise Exception("Max retries exceeded")
+
     try:
         response_headers = get_response_headers(url)
     except Exception as exc:
-        print(f"{url} > Problem with head request\n{exc}\n")
-        return None
+        logger.error(f"{url} > Problem with head request\n{exc}\n")
+        return None, None
     else:
         filetype = response_headers.get("content-type", None)
         if filetype:
@@ -386,4 +333,8 @@ def get_meta_from_url(url):
             return {"content-length": response_headers["content-length"]}, filetype
     return {"default", "default"}, filetype
 
-def is_optimizable()
+
+def is_optimizable(fpath):
+    if fpath.suffix[1:] in VIDEO_FORMATS or fpath.suffix[1:] in IMAGE_FORMATS:
+        return True
+    return False

--- a/openedx2zim/xblocks_extractor/DragAndDropV2.py
+++ b/openedx2zim/xblocks_extractor/DragAndDropV2.py
@@ -34,7 +34,9 @@ class DragAndDropV2(
         # Grid
         name = pathlib.Path(self.content["target_img_expanded_url"]).name
         self.scraper.download_file(
-            prepare_url(self.content["target_img_expanded_url"], self.scraper.instance_url),
+            prepare_url(
+                self.content["target_img_expanded_url"], self.scraper.instance_url
+            ),
             self.output_path.joinpath(name),
         )
         self.content["target_img_expanded_url"] = f"{slugify(self.display_name)}/{name}"

--- a/openedx2zim/xblocks_extractor/DragAndDropV2.py
+++ b/openedx2zim/xblocks_extractor/DragAndDropV2.py
@@ -5,7 +5,7 @@ from bs4 import BeautifulSoup
 from slugify import slugify
 
 from .base_xblock import BaseXblock
-from ..utils import jinja, download
+from ..utils import jinja, prepare_url
 
 
 class DragAndDropV2(
@@ -26,18 +26,16 @@ class DragAndDropV2(
         # item
         for item in self.content["items"]:
             name = pathlib.Path(item["expandedImageURL"]).name
-            download(
-                item["expandedImageURL"],
+            self.scraper.download_file(
+                prepare_url(item["expandedImageURL"], self.scraper.instance_url),
                 self.output_path.joinpath(name),
-                self.scraper.instance_url,
             )
             item["expandedImageURL"] = f"{slugify(self.display_name)}/{name}"
         # Grid
         name = pathlib.Path(self.content["target_img_expanded_url"]).name
-        download(
-            self.content["target_img_expanded_url"],
+        self.scraper.download_file(
+            prepare_url(self.content["target_img_expanded_url"], self.scraper.instance_url),
             self.output_path.joinpath(name),
-            self.scraper.instance_url,
         )
         self.content["target_img_expanded_url"] = f"{slugify(self.display_name)}/{name}"
 

--- a/openedx2zim/xblocks_extractor/FreeTextResponse.py
+++ b/openedx2zim/xblocks_extractor/FreeTextResponse.py
@@ -26,7 +26,7 @@ class FreeTextResponse(BaseXblock):
         save["onclick"] = 'save_freetext("{}")'.format(self.id)
         html_no_answers = '<div class="noanswers"><p data-l10n-id="no_answers_for_freetext" >  <b> Warning : </b> There is not correction for Freetext block. </p> </div>'
         self.html = html_no_answers + dl_dependencies(
-            str(soup), self.output_path, self.folder_name, c
+            str(soup), self.output_path, self.folder_name, c, self.scraper
         )
 
     def render(self):

--- a/openedx2zim/xblocks_extractor/Html.py
+++ b/openedx2zim/xblocks_extractor/Html.py
@@ -17,7 +17,9 @@ class Html(BaseXblock):
         html_content = soup.find("div", attrs={"class": "edx-notes-wrapper"})
         if not html_content:
             html_content = str(soup.find("div", attrs={"class": "course-wrapper"}))
-        self.html = dl_dependencies(html_content, self.output_path, self.folder_name, c, self.scraper)
+        self.html = dl_dependencies(
+            html_content, self.output_path, self.folder_name, c, self.scraper
+        )
 
     def render(self):
         return self.html

--- a/openedx2zim/xblocks_extractor/Html.py
+++ b/openedx2zim/xblocks_extractor/Html.py
@@ -17,7 +17,7 @@ class Html(BaseXblock):
         html_content = soup.find("div", attrs={"class": "edx-notes-wrapper"})
         if not html_content:
             html_content = str(soup.find("div", attrs={"class": "course-wrapper"}))
-        self.html = dl_dependencies(html_content, self.output_path, self.folder_name, c)
+        self.html = dl_dependencies(html_content, self.output_path, self.folder_name, c, self.scraper)
 
     def render(self):
         return self.html

--- a/openedx2zim/xblocks_extractor/Libcast.py
+++ b/openedx2zim/xblocks_extractor/Libcast.py
@@ -4,8 +4,7 @@ from .base_xblock import BaseXblock
 from ..utils import (
     jinja,
     download_and_convert_subtitles,
-    download,
-    convert_video_to_webm,
+    prepare_url,
 )
 
 
@@ -36,21 +35,19 @@ class Libcast(BaseXblock):
                 for lang in subs_lang
             ]
 
-        if self.scraper.convert_in_webm:
+        if self.scraper.video_format == "webm":
             video_path = self.output_path.joinpath("video.webm")
         else:
             video_path = self.output_path.joinpath("video.mp4")
         if not video_path.exists():
-            download(url, video_path, c)
-            if self.scraper.convert_in_webm:
-                convert_video_to_webm(video_path, video_path)
+            self.scraper.download_file(prepare_url(url, self.scraper.instance_url), video_path)
 
     def render(self):
         return jinja(
             None,
             "video.html",
             False,
-            format="webm" if self.scraper.convert_in_webm else "mp4",
+            format=self.scraper.video_format,
             folder_name=self.folder_name,
             title=self.xblock_json["display_name"],
             subs=self.subs,

--- a/openedx2zim/xblocks_extractor/Libcast.py
+++ b/openedx2zim/xblocks_extractor/Libcast.py
@@ -40,7 +40,9 @@ class Libcast(BaseXblock):
         else:
             video_path = self.output_path.joinpath("video.mp4")
         if not video_path.exists():
-            self.scraper.download_file(prepare_url(url, self.scraper.instance_url), video_path)
+            self.scraper.download_file(
+                prepare_url(url, self.scraper.instance_url), video_path
+            )
 
     def render(self):
         return jinja(

--- a/openedx2zim/xblocks_extractor/Lti.py
+++ b/openedx2zim/xblocks_extractor/Lti.py
@@ -18,7 +18,10 @@ class Lti(BaseXblock):
         content = c.get_page(url)
         soup = BeautifulSoup(content, "lxml")
         content_url = soup.find("form")
-        self.scraper.download_file(prepare_url(content_url["action"], self.scraper.instance_url), self.output_path.joinpath("content.pdf"))
+        self.scraper.download_file(
+            prepare_url(content_url["action"], self.scraper.instance_url),
+            self.output_path.joinpath("content.pdf"),
+        )
 
     def render(self):
         return (

--- a/openedx2zim/xblocks_extractor/Lti.py
+++ b/openedx2zim/xblocks_extractor/Lti.py
@@ -1,7 +1,8 @@
 from bs4 import BeautifulSoup
 
 from .base_xblock import BaseXblock
-from ..utils import download
+
+from ..utils import prepare_url
 
 
 class Lti(BaseXblock):
@@ -17,7 +18,7 @@ class Lti(BaseXblock):
         content = c.get_page(url)
         soup = BeautifulSoup(content, "lxml")
         content_url = soup.find("form")
-        download(content_url["action"], self.output_path.joinpath("content.pdf"), c)
+        self.scraper.download_file(prepare_url(content_url["action"], self.scraper.instance_url), self.output_path.joinpath("content.pdf"))
 
     def render(self):
         return (

--- a/openedx2zim/xblocks_extractor/Problem.py
+++ b/openedx2zim/xblocks_extractor/Problem.py
@@ -52,7 +52,7 @@ class Problem(BaseXblock):
             span.decompose()
         html_content = str(soup)
         html_content = dl_dependencies(
-            html_content, self.output_path, self.folder_name, c
+            html_content, self.output_path, self.folder_name, c, self.scraper
         )
         self.html_content = str(html_content)
 

--- a/openedx2zim/xblocks_extractor/Video.py
+++ b/openedx2zim/xblocks_extractor/Video.py
@@ -5,11 +5,7 @@ import urllib
 from bs4 import BeautifulSoup
 
 from .base_xblock import BaseXblock
-from ..utils import (
-    jinja,
-    download_and_convert_subtitles,
-    prepare_url
-)
+from ..utils import jinja, download_and_convert_subtitles, prepare_url
 from ..constants import getLogger
 
 
@@ -109,7 +105,10 @@ class Video(BaseXblock):
             if youtube:
                 self.scraper.download_file(url, video_path)
             else:
-                self.scraper.download_file(prepare_url(urllib.parse.unquote(url), self.scraper.instance_url), video_path)
+                self.scraper.download_file(
+                    prepare_url(urllib.parse.unquote(url), self.scraper.instance_url),
+                    video_path,
+                )
         real_subtitle = download_and_convert_subtitles(self.output_path, subs_lang, c)
         self.subs = [
             {"file": f"{self.folder_name}/{lang}.vtt", "code": lang}

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,7 @@ requests>=2.24,<3.0
 iso-639==0.4.5
 zimscraperlib>=1.1.2,<1.2
 python-magic==0.4.18
+kiwixstorage>=0.2,<1.0
+pif==0.8.2
 # youtube-dl should be updated as frequently as possible
 youtube_dl

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ requests>=2.24,<3.0
 iso-639==0.4.5
 zimscraperlib>=1.1.2,<1.2
 python-magic==0.4.18
-kiwixstorage>=0.2,<1.0
+kiwixstorage>=0.3,<1.0
 pif==0.8.2
 # youtube-dl should be updated as frequently as possible
 youtube_dl


### PR DESCRIPTION
This changes the following
- Add S3 support for images and videos - The S3 key is as follows to accommodate all types of assets -
`{fpath.suffix[1:]}/{safe_url}/{quality}`, where quality is "high", "low", or "default", and safe_url is a S3 safe version of the URL without the scheme.
- Support Mp4 and WebM both - The --format argument is added which has support for both mp4 and WebM. The --low-quality option is also added. (--autoplay is added in options but not connected with the templates yet)
- Refactored download function to manage S3 in single place - The download and optimization is handled by a single function called download_file() that automatically checks for videos and downloads them from youtube if needed. It also provides us a way to have S3 implemented at one place instead of at different places for images and videos.

The following new functions are added -
- download_file() - Downloads a file from given URL to given path.
- generate_s3_key() - Generate a S3 key given the filename and its URL
- optimize_file() - Send the downloaded file to the correct function to optimize
- convert_video() - Converts a video if low quality required or video not in required format. Uses zimscraperlib.video
- optimize_image() - Optimizes an image based on its type
- download_from_youtube() - Uses youtube_dl to download a file from youtube
- download_from_url() - Download a file using save_large_file(), and return path to the downloaded file. It downloads to a temporary file if the mimetype (from the head request) does not match the required file extension. The temp file has an extension same as the mimetype.
- get_meta_from_url() - This basically performs a head request and returns the filetype and meta to store in S3. (Taken from sotoki. Maybe we shall consider having it in the scraperlib).
- is_optimizable() - Return true if the downloaded file is a video/image, i.e. able to optimize
- s3_credentials_ok() - Checks provided S3 credentials
- download_from_cache() - Check if a key is available in cache and matches the meta. If yes, it downloads it and returns true. Also checks the optimizer_version if --use-any-optimized-version is not given. 
- upload_to_cache() - Uploads a file to cache at given key with given meta and optimizer_version if available. Returns True if success, otherwise False


Currently the following work -
- S3 cache download/upload
- Video convertion

The youtube download is not tested right now (will test soon)