### PR TITLE
Do not fail offlining xblock on error with get_page()

### DIFF
--- a/openedx2zim/instance_connection.py
+++ b/openedx2zim/instance_connection.py
@@ -19,7 +19,7 @@ def get_instance_config(instance_netloc):
     return INSTANCE_CONFIGS[instance_netloc]
 
 
-def get_response(url, post_data, headers, max_attempts=2):
+def get_response(url, post_data, headers, max_attempts=5):
     req = urllib.request.Request(url, post_data, headers)
     for attempt in range(max_attempts):
         try:
@@ -27,6 +27,8 @@ def get_response(url, post_data, headers, max_attempts=2):
         except Exception as exc:
             if attempt < max_attempts - 1:
                 logger.debug(f"Error opening {url}: {exc}\nRetrying ...")
+            else:
+                logger.debug(f"Error opening {url}: {exc}")
     logger.error(f"Max attempts exceeded for {url}")
     return {}
 

--- a/openedx2zim/scraper.py
+++ b/openedx2zim/scraper.py
@@ -562,8 +562,9 @@ class Openedx2Zim:
 
         # make xblock_extractor objects download their content
         logger.info("Getting content for supported xblocks ...")
-        for obj in self.xblock_extractor_objects:
-            obj.download(self.instance_connection)
+        # for obj in self.xblock_extractor_objects:
+        #     obj.download(self.instance_connection)
+        self.head_course_xblock.download(self.instance_connection)
 
     def s3_credentials_ok(self):
         logger.info("Testing S3 Optimization Cache credentials ...")

--- a/openedx2zim/scraper.py
+++ b/openedx2zim/scraper.py
@@ -285,6 +285,9 @@ class Openedx2Zim:
     def annex(self):
         logger.info("Getting course tabs ...")
         content = self.instance_connection.get_page(self.course_url)
+        if not content:
+            logger.error("Failed to get course tabs")
+            raise SystemExit(1)
         soup = BeautifulSoup(content, "lxml")
         course_tabs = (
             soup.find("ol", attrs={"class": "course-material"})
@@ -332,6 +335,9 @@ class Openedx2Zim:
                     page_content = self.instance_connection.get_page(
                         self.instance_url + tab["href"]
                     )
+                    if not page_content:
+                        logger.error(f"Failed to get page content for tab {tab_path}")
+                        raise SystemExit(1)
                     soup_page = BeautifulSoup(page_content, "lxml")
                     just_content = soup_page.find(
                         "section", attrs={"class": "container"}
@@ -517,6 +523,9 @@ class Openedx2Zim:
         # get the course url and generate homepage
         logger.info("Getting homepage ...")
         content = self.instance_connection.get_page(self.course_url)
+        if not content:
+            logger.error("Error while getting homepage")
+            raise SystemExit(1)
         self.build_dir.joinpath("home").mkdir(parents=True, exist_ok=True)
         soup = BeautifulSoup(content, "lxml")
         welcome_message = soup.find("div", attrs={"class": "welcome-message"})

--- a/openedx2zim/xblocks_extractor/discussion.py
+++ b/openedx2zim/xblocks_extractor/discussion.py
@@ -22,6 +22,8 @@ class Discussion(BaseXblock):
     def download(self, instance_connection):
         if self.scraper.forum_thread:
             content = instance_connection.get_page(self.xblock_json["student_view_url"])
+            if not content:
+                return
             soup = BeautifulSoup(content, "lxml")
             discussion_block = soup.find(
                 re.compile(r".*"), {"data-discussion-id": re.compile(r".*")}

--- a/openedx2zim/xblocks_extractor/drag_and_drop_v2.py
+++ b/openedx2zim/xblocks_extractor/drag_and_drop_v2.py
@@ -23,6 +23,8 @@ class DragAndDropV2(
 
     def download(self, instance_connection):
         content = instance_connection.get_page(self.xblock_json["student_view_url"])
+        if not content:
+            return
         soup = BeautifulSoup(content, "lxml")
         self.content = json.loads(
             soup.find("script", attrs={"class": "xblock-json-init-args"}).string.strip()

--- a/openedx2zim/xblocks_extractor/free_text_response.py
+++ b/openedx2zim/xblocks_extractor/free_text_response.py
@@ -17,6 +17,8 @@ class FreeTextResponse(BaseXblock):
 
     def download(self, instance_connection):
         content = instance_connection.get_page(self.xblock_json["student_view_url"])
+        if not content:
+            return
         soup = BeautifulSoup(content, "lxml")
         html_content = soup.find("div", attrs={"class": "edx-notes-wrapper"})
         if not html_content:

--- a/openedx2zim/xblocks_extractor/html.py
+++ b/openedx2zim/xblocks_extractor/html.py
@@ -16,6 +16,8 @@ class Html(BaseXblock):
 
     def download(self, instance_connection):
         content = instance_connection.get_page(self.xblock_json["student_view_url"])
+        if not content:
+            return
         soup = BeautifulSoup(content, "lxml")
         html_content = soup.find("div", attrs={"class": "edx-notes-wrapper"})
         if not html_content:

--- a/openedx2zim/xblocks_extractor/libcast.py
+++ b/openedx2zim/xblocks_extractor/libcast.py
@@ -21,6 +21,8 @@ class Libcast(BaseXblock):
 
     def download(self, instance_connection):
         content = instance_connection.get_page(self.xblock_json["student_view_url"])
+        if not content:
+            return
         soup = BeautifulSoup(content, "lxml")
         url = str(soup.find("video").find("source")["src"])
         subs = soup.find("video").find_all("track")

--- a/openedx2zim/xblocks_extractor/lti.py
+++ b/openedx2zim/xblocks_extractor/lti.py
@@ -20,6 +20,8 @@ class Lti(BaseXblock):
             + "/handler/preview_handler"
         )
         content = instance_connection.get_page(url)
+        if not content:
+            return
         soup = BeautifulSoup(content, "lxml")
         content_url = soup.find("form")
         self.scraper.download_file(

--- a/openedx2zim/xblocks_extractor/problem.py
+++ b/openedx2zim/xblocks_extractor/problem.py
@@ -28,6 +28,8 @@ class Problem(BaseXblock):
 
     def download(self, instance_connection):
         content = instance_connection.get_page(self.xblock_json["student_view_url"])
+        if not content:
+            return
         soup = BeautifulSoup(content, "lxml")
         try:
             html_content_from_div = str(

--- a/openedx2zim/xblocks_extractor/video.py
+++ b/openedx2zim/xblocks_extractor/video.py
@@ -28,6 +28,8 @@ class Video(BaseXblock):
         youtube = False
         if "student_view_data" not in self.xblock_json:
             content = instance_connection.get_page(self.xblock_json["student_view_url"])
+            if not content:
+                return
             soup = BeautifulSoup.BeautifulSoup(content, "lxml")
             url = str(soup.find("video").find("source")["src"])
             subs = soup.find("video").find_all("track")
@@ -74,6 +76,8 @@ class Video(BaseXblock):
                 content = instance_connection.get_page(
                     self.xblock_json["student_view_url"]
                 )
+                if not content:
+                    return
                 soup = BeautifulSoup.BeautifulSoup(content, "lxml")
                 youtube_json = soup.find("div", attrs={"id": re.compile("^video_")})
                 if youtube_json and youtube_json.has_attr("data-metadata"):


### PR DESCRIPTION
The zimfarm run failed with -
```
[openedx2zim::2020-07-14 14:08:04,013] DEBUG:Error opening https://mooc.phzh.ch/xblock/block-v1:PHZH+W-IB+2019_E+type@html+block@d37268bab8bc41fc9b7a2067479c3e00: HTTP Error 502: Bad Gateway
Retrying ...
[openedx2zim::2020-07-14 14:08:05,560] ERROR:Max attempts exceeded for https://mooc.phzh.ch/xblock/block-v1:PHZH+W-IB+2019_E+type@html+block@d37268bab8bc41fc9b7a2067479c3e00
[openedx2zim::2020-07-14 14:08:05,560] ERROR:FAILED. An error occurred: unhashable type: 'slice'
[openedx2zim::2020-07-14 14:08:05,560] ERROR:unhashable type: 'slice'
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/openedx2zim-1.0.0.dev0-py3.8.egg/openedx2zim/entrypoint.py", line 169, in main
    scraper.run()
  File "/usr/local/lib/python3.8/site-packages/openedx2zim-1.0.0.dev0-py3.8.egg/openedx2zim/scraper.py", line 802, in run
    self.get_content()
  File "/usr/local/lib/python3.8/site-packages/openedx2zim-1.0.0.dev0-py3.8.egg/openedx2zim/scraper.py", line 557, in get_content
    obj.download(self.instance_connection)
  File "/usr/local/lib/python3.8/site-packages/openedx2zim-1.0.0.dev0-py3.8.egg/openedx2zim/xblocks_extractor/chapter.py", line 14, in download
    x.download(instance_connection)
  File "/usr/local/lib/python3.8/site-packages/openedx2zim-1.0.0.dev0-py3.8.egg/openedx2zim/xblocks_extractor/sequential.py", line 14, in download
    x.download(instance_connection)
  File "/usr/local/lib/python3.8/site-packages/openedx2zim-1.0.0.dev0-py3.8.egg/openedx2zim/xblocks_extractor/vertical.py", line 25, in download
    x.download(instance_connection)
  File "/usr/local/lib/python3.8/site-packages/openedx2zim-1.0.0.dev0-py3.8.egg/openedx2zim/xblocks_extractor/html.py", line 19, in download
    soup = BeautifulSoup(content, "lxml")
  File "/usr/local/lib/python3.8/site-packages/bs4/__init__.py", line 339, in __init__
    for (self.markup, self.original_encoding, self.declared_html_encoding,
  File "/usr/local/lib/python3.8/site-packages/bs4/builder/_lxml.py", line 184, in prepare_markup
    detector = EncodingDetector(
  File "/usr/local/lib/python3.8/site-packages/bs4/dammit.py", line 264, in __init__
    self.markup, self.sniffed_encoding = self.strip_byte_order_mark(markup)
  File "/usr/local/lib/python3.8/site-packages/bs4/dammit.py", line 337, in strip_byte_order_mark
    elif data[:3] == b'\xef\xbb\xbf':
TypeError: unhashable type: 'slice'
```
This seems to be due to the `{}` being returned by get_response if error happened with request. So, we prevent this by skipping the download process if this happens. Also, increased the number of attempts from 2 to 5.

Also, pushed a change to avoid processing xblocks multiple times as the root xblock's download method would automatically run the download method of its descendants. So there's no need to call download method of each xblock_extractor explicitly in a loop. This lowers the number of HTTP requests drastically and reduces the offlining time. (Went from 2 hours to 15 minutes on [this](https://courses.edx.org/courses/course-v1:edX+edx201+1T2020/course/) edX course)