### PR TITLE
Add fallback videojs-ogvjs for extended WebM support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,12 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# External assets
+openedx2zim/templates/assets/fonts/
+openedx2zim/templates/assets/fontawesome/
+openedx2zim/templates/assets/videojs/
+openedx2zim/templates/assets/mathjax/
+openedx2zim/templates/assets/ogvjs/
+openedx2zim/templates/assets/jquery.min.js
+openedx2zim/templates/assets/videojs-ogvjs.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@
 - refactored Dockerfile
 - add s3 based optimization cache
 - removed javascript dependencies from repository
+- add support for webm on systems without native support

--- a/get_js_deps.sh
+++ b/get_js_deps.sh
@@ -53,6 +53,26 @@ rm -rf $ASSETS_PATH/MathJax-3.0.5
 rm -f 3.0.5.zip
 
 echo "getting jquery.min.js"
-rm -rf $ASSETS_PATH/jquery
-mkdir -p $ASSETS_PATH/jquery
-curl -L -o $ASSETS_PATH/jquery/jquery.min.js https://code.jquery.com/jquery-3.5.1.min.js
+curl -L -o $ASSETS_PATH/jquery.min.js https://code.jquery.com/jquery-3.5.1.min.js
+
+echo "getting ogv.js"
+curl -L -O https://github.com/brion/ogv.js/releases/download/1.6.1/ogvjs-1.6.1.zip
+rm -rf $ASSETS_PATH/ogvjs
+unzip -o ogvjs-1.6.1.zip
+mv ogvjs-1.6.1 $ASSETS_PATH/ogvjs
+rm -f ogvjs-1.6.1.zip
+
+echo "getting videojs-ogvjs.js"
+curl -L -O https://github.com/hartman/videojs-ogvjs/archive/v1.3.1.zip
+rm -f $ASSETS_PATH/videojs-ogvjs.js
+unzip -o v1.3.1.zip
+mv videojs-ogvjs-1.3.1/dist/videojs-ogvjs.js $ASSETS_PATH/videojs-ogvjs.js
+rm -rf videojs-ogvjs-1.3.1
+rm -f v1.3.1.zip
+
+if command -v fix_ogvjs_dist > /dev/null; then
+    echo "fixing JS files"
+    fix_ogvjs_dist $ASSETS_PATH "assets"
+else
+    echo "NOT fixing JS files (zimscraperlib not installed)"
+fi

--- a/openedx2zim/annex.py
+++ b/openedx2zim/annex.py
@@ -24,10 +24,7 @@ class MoocForum:
 
     def add_categories(self, categories):
         for category in categories:
-            if (
-                category.has_attr("id")
-                and category["id"] in ["all_discussions", "posts_following"]
-            ) or (
+            if (category.get("id") in ["all_discussions", "posts_following"]) or (
                 category.has_attr("class")
                 and (
                     "forum-nav-browse-menu-all" in category["class"]

--- a/openedx2zim/entrypoint.py
+++ b/openedx2zim/entrypoint.py
@@ -43,6 +43,13 @@ def main():
     )
 
     parser.add_argument(
+        "--autoplay",
+        help="Enable autoplay on videos. Behavior differs on platforms/browsers.",
+        action="store_true",
+        default=False,
+    )
+
+    parser.add_argument(
         "--name",
         help="ZIM name. Used as identifier and filename (date will be appended)",
         required=True,

--- a/openedx2zim/scraper.py
+++ b/openedx2zim/scraper.py
@@ -86,6 +86,7 @@ class Openedx2Zim:
         password,
         video_format,
         low_quality,
+        autoplay,
         name,
         title,
         description,
@@ -143,6 +144,7 @@ class Openedx2Zim:
         self.add_wiki = add_wiki
         self.add_forum = add_forum
         self.ignore_missing_xblocks = ignore_missing_xblocks
+        self.autoplay = autoplay
 
         # authentication
         self.email = email
@@ -480,6 +482,7 @@ class Openedx2Zim:
                             format=self.video_format,
                             video_path=filename,
                             subs=[],
+                            autoplay=self.autoplay,
                         )
                         iframe.getparent().replace(iframe, lxml.html.fromstring(x))
                 elif ".pdf" in src:

--- a/openedx2zim/templates/assets/zim_prefix.js
+++ b/openedx2zim/templates/assets/zim_prefix.js
@@ -1,0 +1,54 @@
+
+/* Generic Zimwriterfs-related properties */
+isInZIM = function() { return document.getElementById("favicon").getAttribute("href").indexOf("/I/") !== -1; }
+IS_IN_ZIM = isInZIM();
+
+getImageNamespacePrefix = function() { return document.getElementById("favicon").getAttribute("href").replace("favicon.png", ""); }
+ZIM_IMG_NS = getImageNamespacePrefix();
+
+getMetaNamespacePrefix = function() { return ZIM_IMG_NS.replace("/I/", "/-/"); }
+ZIM_META_NS = getMetaNamespacePrefix();
+
+hasImageNamespacePrefix = function(target) { return target.indexOf(ZIM_IMG_NS) !== -1;}
+hasMetaNamespacePrefix = function(target) { return target.indexOf(ZIM_META_NS) !== -1;}
+changeNamespacePrefix = function(target, new_ns) {
+    let avail_ns = ["A", "-", "I"];
+    new_ns = new_ns.toUpperCase();
+    if (avail_ns.indexOf(new_ns) == -1) {
+        throw ("Invalid NS: " + new_ns);
+    }
+    let ns_char = -1;
+    avail_ns.forEach(function (namespace) {
+        if (ns_char == -1) {
+            ns_char = target.indexOf("/" + namespace + "/");
+        }
+    });
+    if (ns_char == -1) {
+        // missing prefix
+        return target;
+    }
+
+    return target.slice(0, ns_char + 1) + new_ns + target.slice(ns_char + 2);
+}
+
+/* ogv.js related bits */
+zim_fix_wasm_target = function(target) {
+    console.debug("zim_fix_wasm_target:", target);
+    if (!IS_IN_ZIM) {
+        console.debug("..not in zim");
+        return target;
+    }
+    if (hasImageNamespacePrefix(target)) {
+        // we already have a good path, leave it
+    }
+    else if (hasMetaNamespacePrefix(target)) {
+        // we have a prefix, just replace it
+        target = changeNamespacePrefix(target, "I");
+    }
+    else {
+        // we lack the prefix, add it
+        target = ZIM_IMG_NS + "assets/ogvjs/" + target;
+    }
+    console.debug("..target:", target);
+    return target;
+}

--- a/openedx2zim/templates/base.html
+++ b/openedx2zim/templates/base.html
@@ -6,15 +6,18 @@
     <meta name="generator" content="https://github.com/openzim/openedx/"/>
     <meta name="author" content="kiwix team"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <link id="favicon" rel="shortcut icon" href="{{ rooturl }}/favicon.png" type="image/png">
     <link href="{{ rooturl }}assets/main.css" rel="stylesheet" type="text/css" />
     <link href="{{ rooturl }}assets/fontawesome/css/all.css" rel="stylesheet" type="text/css" />
     <link href="{{ rooturl }}assets/videojs/video-js.min.css" rel="stylesheet" type="text/css">
-    <script type="text/javascript" src="{{ rooturl }}assets/jquery/jquery.min.js"></script>
+    <script src="{{ rooturl }}assets/zim_prefix.js"></script>
+    <script type="{{ rooturl }}text/javascript" src="{{ rooturl }}assets/jquery.min.js"></script>
     <script src="{{ rooturl }}assets/videojs/video.min.js"></script>
+    <script src="{{ rooturl }}assets/ogvjs/ogv-support.js"></script>
+    <script src="{{ rooturl }}assets/ogvjs/ogv.js"></script>
+    <script src="{{ rooturl }}assets/videojs-ogvjs.js"></script>
     {% block addhead %}{% endblock %}
     <script type="text/javascript" src="{{ rooturl }}assets/mooc.js"></script>
-    <script type="application/l10n">{% include "l10n_strings.json" %}</script>
-    <link rel="icon" type="image/png" href="{{ rooturl }}/favicon.png">
   </head>
   <body class="{% block bodyclass %}{% endblock %}">
     <div class="topmobilebar">

--- a/openedx2zim/templates/video.html
+++ b/openedx2zim/templates/video.html
@@ -1,6 +1,9 @@
 {% if self.no_video != False %}
 {% if title %} <h2> {{ title }} </h2> {% endif %}
-<video class="video video-js vjs-default-skin vjs-big-play-centered" controls preload="auto" width="480px" height="270px" data-setup='{"autoplay": false, "preload": "true", "playbackRates": [0.5, 0.75, 1, 1.25, 1.5, 2, 4, 8]}' >
+<video class="video video-js vjs-default-skin" 
+  controls preload="auto"
+  width="480px" height="270px"
+  data-setup='{"techOrder": ["html5", "ogvjs"], "ogvjs": {"base": "assets/ogvjs"}, "autoplay": {% if autoplay %}true{% else %}false{% endif %}, "preload": true, "controls": true, "controlBar": {"pictureInPictureToggle":false}}'>
   <source src="{{ video_path }}" type="video/{{ format }}" />
   {% for language in subs %}
     <track kind="subtitles" src="{{ language["file"] }}" srclang="{{ language["code"] }}" label="{{ language["code"] }}" />

--- a/openedx2zim/xblocks_extractor/libcast.py
+++ b/openedx2zim/xblocks_extractor/libcast.py
@@ -61,4 +61,5 @@ class Libcast(BaseXblock):
             video_path=f"{self.folder_name}/video.{self.scraper.video_format}",
             title=self.xblock_json["display_name"],
             subs=self.subs,
+            autoplay=self.scraper.autoplay,
         )

--- a/openedx2zim/xblocks_extractor/video.py
+++ b/openedx2zim/xblocks_extractor/video.py
@@ -138,4 +138,5 @@ class Video(BaseXblock):
             video_path=f"{self.folder_name}/video.{self.scraper.video_format}",
             title=self.xblock_json["display_name"],
             subs=self.subs,
+            autoplay=self.scraper.autoplay,
         )


### PR DESCRIPTION
This one does the following changes -
- Add support for ogvjs-videojs as a fallback player on devices that do not support WebM natively
- Add `--autoplay` to the arguments - Makes videos play automatically on page visit if the platform supports it
- Change path for jquery.min.js
- Disable PiP toggle button in video player

This fixes #64