### PR TITLE
Fix small favicons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,4 @@
 - add s3 based optimization cache
 - removed javascript dependencies from repository
 - add support for webm on systems without native support
+- fix small favicons

--- a/openedx2zim/constants.py
+++ b/openedx2zim/constants.py
@@ -48,6 +48,7 @@ INSTANCE_CONFIGS = {
         "course_page_name": "/course",
         "course_prefix": "/courses/",
         "instance_url": "https://courses.edx.org",
+        "favicon_url": "https://courses.edx.org/favicon.ico",
     },
     "courses.edraak.org": {
         "login_page": "/login_ajax",
@@ -55,6 +56,7 @@ INSTANCE_CONFIGS = {
         "course_page_name": "/",
         "course_prefix": "/courses/",
         "instance_url": "https://courses.edraak.org",
+        "favicon_url": "https://courses.edraak.org/favicon.ico",
     },
     "mooc.phzh.ch": {
         "login_page": "/login_ajax",
@@ -62,6 +64,7 @@ INSTANCE_CONFIGS = {
         "course_page_name": "/course",
         "course_prefix": "/courses/",
         "instance_url": "https://mooc.phzh.ch",
+        "favicon_url": "https://mooc.phzh.ch/favicon.ico",
     },
     "default": {
         "login_page": "/login_ajax",
@@ -69,6 +72,7 @@ INSTANCE_CONFIGS = {
         "course_page_name": "/info",
         "course_prefix": "/courses/",
         "instance_url": "",
+        "favicon_url": None,
     },
 }
 

--- a/openedx2zim/instance_connection.py
+++ b/openedx2zim/instance_connection.py
@@ -13,7 +13,10 @@ logger = getLogger()
 def get_instance_config(instance_netloc):
     if instance_netloc not in INSTANCE_CONFIGS:
         INSTANCE_CONFIGS["default"].update(
-            {"instance_url": f"https://{instance_netloc}"}
+            {
+                "instance_url": f"https://{instance_netloc}",
+                "favicon_url": f"https://{instance_netloc}/favicon.ico",
+            }
         )
         return INSTANCE_CONFIGS["default"]
     return INSTANCE_CONFIGS[instance_netloc]


### PR DESCRIPTION
This does the following changes to fix #65 -
- Add `favicon_url` in instance config to point to an image for the favicon
- Add get_favicon() in scraper.py to use the explicit favicon URL, or fallback to getting favicon.ico from the root or the one provided by openedx.