### PR TITLE
Add params to get instance config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@
 - fix small favicons
 - use pylibzim for creating ZIMs
 - fix internal links
+- use params instead of instance configs

--- a/openedx2zim/constants.py
+++ b/openedx2zim/constants.py
@@ -41,41 +41,6 @@ DOWNLOADABLE_EXTENSIONS = [
     ".r",
 ]
 
-INSTANCE_CONFIGS = {
-    "courses.edx.org": {
-        "login_page": "/login_ajax",
-        "account_page": "/account/settings",
-        "course_page_name": "/course",
-        "course_prefix": "/courses/",
-        "instance_url": "https://courses.edx.org",
-        "favicon_url": "https://edx.org/favicon.ico",
-    },
-    "courses.edraak.org": {
-        "login_page": "/login_ajax",
-        "account_page": "/account/settings",
-        "course_page_name": "/",
-        "course_prefix": "/courses/",
-        "instance_url": "https://courses.edraak.org",
-        "favicon_url": "https://courses.edraak.org/favicon.ico",
-    },
-    "mooc.phzh.ch": {
-        "login_page": "/login_ajax",
-        "account_page": "/account/settings",
-        "course_page_name": "/course",
-        "course_prefix": "/courses/",
-        "instance_url": "https://mooc.phzh.ch",
-        "favicon_url": "https://mooc.phzh.ch/favicon.ico",
-    },
-    "default": {
-        "login_page": "/login_ajax",
-        "account_page": "/account/settings",
-        "course_page_name": "/info",
-        "course_prefix": "/courses/",
-        "instance_url": "",
-        "favicon_url": None,
-    },
-}
-
 UNSUPPORTED_XBLOCKS = {"grademebutton": "Grade Me (Unavailable Offline)"}
 
 

--- a/openedx2zim/entrypoint.py
+++ b/openedx2zim/entrypoint.py
@@ -72,7 +72,7 @@ def main():
 
     parser.add_argument(
         "--tags",
-        help="List of comma-separated Tags for the ZIM file. category:openedx, openedx, and _videos:yes (if present) added automatically",
+        help="List of comma-separated Tags for the ZIM file. category:other, openedx, and _videos:yes (if present) added automatically",
     )
 
     parser.add_argument(
@@ -83,8 +83,27 @@ def main():
     )
 
     parser.add_argument(
-        "--lang",
-        help="Default language of the interface and the ZIM content (ISO-639-1 codes)",
+        "--instance-login-page",
+        help="The login path in the instance. Must start with /",
+        default="/login_ajax",
+    )
+
+    parser.add_argument(
+        "--instance-course-page",
+        help="The path to the course page after the course ID. Must start with /",
+        default="/course",
+    )
+
+    parser.add_argument(
+        "--instance-course-prefix",
+        help="The prefix in the path before the course ID. Must start and end with /",
+        default="/courses/",
+    )
+
+    parser.add_argument(
+        "--favicon-url",
+        help="URL pointing to a favicon image. Recommended size >= (48px x 48px)",
+        default="https://github.com/edx/edx-platform/raw/master/lms/static/images/favicon.ico",
     )
 
     parser.add_argument(

--- a/openedx2zim/html_processor.py
+++ b/openedx2zim/html_processor.py
@@ -184,7 +184,7 @@ class HtmlProcessor:
                 )
 
         anchors = html_body.xpath("//a")
-        path_prefix = f"{self.scraper.instance_connection.instance_config['course_prefix']}{urllib.parse.unquote_plus(self.scraper.course_id)}"
+        path_prefix = f"{self.scraper.instance_config['course_prefix']}{urllib.parse.unquote_plus(self.scraper.course_id)}"
         has_changed = False
         for anchor in anchors:
             if "href" not in anchor.attrib:

--- a/openedx2zim/instance_connection.py
+++ b/openedx2zim/instance_connection.py
@@ -5,21 +5,9 @@ import json
 import sys
 import urllib
 
-from .constants import INSTANCE_CONFIGS, getLogger
+from .constants import getLogger
 
 logger = getLogger()
-
-
-def get_instance_config(instance_netloc):
-    if instance_netloc not in INSTANCE_CONFIGS:
-        INSTANCE_CONFIGS["default"].update(
-            {
-                "instance_url": f"https://{instance_netloc}",
-                "favicon_url": f"https://{instance_netloc}/favicon.ico",
-            }
-        )
-        return INSTANCE_CONFIGS["default"]
-    return INSTANCE_CONFIGS[instance_netloc]
 
 
 def get_response(url, post_data, headers, max_attempts=5):
@@ -37,12 +25,10 @@ def get_response(url, post_data, headers, max_attempts=5):
 
 
 class InstanceConnection:
-    def __init__(self, course_url, email, password):
-        self.instance_netloc = urllib.parse.urlparse(course_url)[1]
+    def __init__(self, email, password, instance_config):
         self.email = email
         self.password = password if password else getpass.getpass(stream=sys.stderr)
-
-        self.instance_config = get_instance_config(self.instance_netloc)
+        self.instance_config = instance_config
         self.cookie_jar = http.cookiejar.LWPCookieJar("lol.cookies")
         self.headers = None
         self.instance_connection = None


### PR DESCRIPTION
This fixed #86 by adding parameters in openedx to get the instance config and removes the hardcoded values. The following new parameters are there -
- ~~--instance-account-page~~ - Removed as it was useless
- --instance-course-prefix
- --instance-course-page
- --instance-login-page
- --favicon-url - This has the default value for the favicon URL and hence no fallback mechanism is needed now.
I have added default values for these so that running is easier.
The following parameters are removed -
- --lang - Removed as we create in eng only for now. When we add proper multilingual support, we would add the --language parameter.  