### PR TITLE
Fix path errors

### DIFF
--- a/openedx2zim/scraper.py
+++ b/openedx2zim/scraper.py
@@ -220,6 +220,9 @@ class Openedx2Zim:
     def parse_course_xblocks(self):
         def make_objects(current_path, current_id, root_url):
             current_xblock = self.course_xblocks[current_id]
+            # ensure the display name is not empty to avoid path issues
+            if not current_xblock["display_name"]:
+                current_xblock["display_name"] = "xblock"
             xblock_path = current_path.joinpath(slugify(current_xblock["display_name"]))
 
             # update root url respective to the current xblock


### PR DESCRIPTION
This fixes #89 by writing only the filename if asset is at the root relative to the HTML. Also, add support for jump_to_xblock kind of link found in PHZH for links rewriting. Moreover, this also ensures that the display_name is not empty for any xblock as it would result in root relative links which are forbidden in ZIM.