### PR TITLE
Fetch CSS and JS from instance to have proper layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,4 @@
 - use pylibzim for creating ZIMs
 - fix internal links
 - use params instead of instance configs
+- use course layout from instance

--- a/openedx2zim/html_processor.py
+++ b/openedx2zim/html_processor.py
@@ -1,11 +1,12 @@
 import hashlib
 import pathlib
+import re
 import urllib
 
 import lxml.html
 
 from .constants import DOWNLOADABLE_EXTENSIONS
-from .utils import prepare_url, jinja
+from .utils import jinja, prepare_url
 
 
 class HtmlProcessor:
@@ -27,12 +28,66 @@ class HtmlProcessor:
         filename = hashlib.sha256(str(src).encode("utf-8")).hexdigest() + ext
         output_file = output_path.joinpath(filename)
         if filter_ext and ext not in filter_ext:
-            return
+            return None, None
+        fresh_download = False
         if not output_file.exists():
             self.scraper.download_file(
                 prepare_url(src, self.scraper.instance_url), output_file,
             )
-        return filename
+            fresh_download = True
+        return filename, fresh_download
+
+    def download_dependencies_from_css(
+        self, css_org_url, content, folder, path_from_css
+    ):
+        """ Download all dependencies from CSS file contained in url()
+
+            - css_org_url: URL to the CSS file on the internet
+            - content: CSS text to rewrite
+            - folder: “parent” folder of CSS to download files to
+            - path_from_css: path of the supplied folder from CSS """
+
+        def encapsulate(url):
+            return f"url({url})"
+
+        # ensure the original CSS url has netloc
+        css_org_url = prepare_url(css_org_url, self.scraper.instance_url)
+        css_org_url = urllib.parse.urlparse(css_org_url)
+
+        # split whole content on `url()` pattern to retrieve a list composed of
+        # alternatively pre-pattern text and inside url() –– actual target text
+        parts = re.split(r"url\((.+?)\)", content)
+        for index, _ in enumerate(parts):
+            if index % 2 == 0:  # skip even lines (0, 2, ..) as those are CSS code
+                continue
+            css_url = parts[index]  # css_urls are on odd lines
+
+            # remove potential quotes (can be none, single or double)
+            if css_url[0] and css_url[-1] == "'":
+                css_url = css_url[1:-1]
+            if css_url[0] and css_url[-1] == '"':
+                css_url = css_url[1:-1]
+
+            # don't rewrite data: and empty URLs
+            if re.match(r"^(://|data:|#)", css_url):
+                parts[index] = encapsulate(css_url)
+                continue
+
+            # add netloc if not present
+            parsed_url = urllib.parse.urlparse(css_url)
+            if parsed_url.netloc == "":
+                if parsed_url.path.startswith("/"):
+                    css_url = self.scraper.instance_url + css_url
+                else:
+                    css_url = css_org_url.netloc + str(
+                        pathlib.Path(css_org_url.path).parent.joinpath(css_url)
+                    )
+
+            # download the file
+            filename, _ = self.download_and_get_filename(css_url, folder)
+            fixed = filename if not path_from_css else f"{path_from_css}/{filename}"
+            parts[index] = encapsulate(fixed)
+        return "".join(parts)
 
     def download_images_from_html(self, html_body, output_path, path_from_html):
         """ download images from <img> tag and fix path """
@@ -40,7 +95,7 @@ class HtmlProcessor:
         imgs = html_body.xpath("//img")
         for img in imgs:
             if "src" in img.attrib:
-                filename = self.download_and_get_filename(
+                filename, _ = self.download_and_get_filename(
                     src=img.attrib["src"], output_path=output_path
                 )
                 if filename:
@@ -61,7 +116,7 @@ class HtmlProcessor:
         anchors = html_body.xpath("//a")
         for anchor in anchors:
             if "href" in anchor.attrib:
-                filename = self.download_and_get_filename(
+                filename, _ = self.download_and_get_filename(
                     src=anchor.attrib["href"],
                     output_path=output_path,
                     filter_ext=DOWNLOADABLE_EXTENSIONS,
@@ -80,10 +135,21 @@ class HtmlProcessor:
         css_files = html_body.xpath("//link")
         for css in css_files:
             if "href" in css.attrib:
-                filename = self.download_and_get_filename(
+                filename, fresh_download = self.download_and_get_filename(
                     src=css.attrib["href"], output_path=output_path
                 )
                 if filename:
+                    if fresh_download:
+                        css_fpath = output_path.joinpath(filename)
+                        with open(css_fpath, "r") as fh:
+                            fixed = self.download_dependencies_from_css(
+                                css.attrib["href"],
+                                fh.read(),
+                                folder=css_fpath.parent,
+                                path_from_css="",
+                            )
+                        with open(css_fpath, "w") as fh:
+                            fh.write(fixed)
                     css.attrib["href"] = (
                         f"{filename}"
                         if not path_from_html
@@ -97,7 +163,7 @@ class HtmlProcessor:
         js_files = html_body.xpath("//script")
         for js in js_files:
             if "src" in js.attrib:
-                filename = self.download_and_get_filename(
+                filename, _ = self.download_and_get_filename(
                     src=js.attrib["src"], output_path=output_path
                 )
                 if filename:
@@ -114,7 +180,7 @@ class HtmlProcessor:
         sources = html_body.xpath("//source")
         for source in sources:
             if "src" in source.attrib:
-                filename = self.download_and_get_filename(
+                filename, _ = self.download_and_get_filename(
                     src=source.attrib["src"], output_path=output_path
                 )
                 if filename:
@@ -133,7 +199,7 @@ class HtmlProcessor:
             if "src" in iframe.attrib:
                 src = iframe.attrib["src"]
                 if "youtube" in src:
-                    filename = self.download_and_get_filename(
+                    filename, _ = self.download_and_get_filename(
                         src=src,
                         output_path=output_path,
                         with_ext=f".{self.scraper.video_format}",
@@ -152,7 +218,7 @@ class HtmlProcessor:
                         )
                         iframe.getparent().replace(iframe, lxml.html.fromstring(x))
                 elif ".pdf" in src:
-                    filename = self.download_and_get_filename(
+                    filename, _ = self.download_and_get_filename(
                         src=src, output_path=output_path
                     )
                     if filename:
@@ -231,7 +297,7 @@ class HtmlProcessor:
                         # xblock may be one of those from which a vertical is consisted of
                         # thus check if the parent has the valid path
                         # we only need to check one layer deep as there's single layer of xblocks beyond vertical
-                        path_fixed = self.handle_jump_to_paths(str(src_path.parent))
+                        path_fixed = self.handle_jump_to_paths(src_path.parent)
                     update_root_relative_path(anchor, path_fixed, output_path)
                     has_changed = True
                 else:

--- a/openedx2zim/templates/assets/main.css
+++ b/openedx2zim/templates/assets/main.css
@@ -80,7 +80,7 @@ a {
 a {
     color: #005584;
 }
-.content-wrapper{
+.zim-content-wrapper{
   flex:1;
   border:none;
   width:100%;
@@ -169,7 +169,7 @@ table {
 margin: 0 auto 0;
   width:100%;
 }
-.course-material, .preview-menu{
+.zim-course-material, .preview-menu{
 width: auto;
 padding: 15px 2%;
 margin: 0 auto;
@@ -178,25 +178,25 @@ width: 100%;
 overflow: auto;
 }
 
-.wrapper-course-material .course-material .course-tabs {
+.zim-wrapper-course-material .zim-course-material .zim-course-tabs {
       padding: 0;
 }
 
-.wrapper-course-material ol.course-tabs {
+.zim-wrapper-course-material ol.zim-course-tabs {
     border-top-left-radius: 4px;
     border-top-right-radius: 4px;
 /*    margin-left: 10px;*/
     padding: 15px 0 15px 0;
 }
 
-ol.course-tabs li {
+ol.zim-course-tabs li {
   float: left;
   list-style: none;
   margin-right: 6px;
 }
 
 
-ol.course-tabs li a.active {
+ol.zim-course-tabs li a.zim-active {
     background-color: rgba(0,0,0,0.4);
     background-image: linear-gradient(to bottom,rgba(0,0,0,0.4),rgba(0,0,0,0.25));
     background-color: transparent;
@@ -204,7 +204,7 @@ ol.course-tabs li a.active {
     color: #fff;
     text-shadow: 0 1px 0 rgba(0,0,0,0.4);
 }
-ol.course-tabs li a {
+ol.zim-course-tabs li a {
     border-radius: 3px;
     color: #555;
     display: block;
@@ -235,7 +235,7 @@ ol.course-tabs li a {
 }
 
 
-.container {
+.zim-container {
     max-width: none;
     min-width: initial;
     width: auto;
@@ -245,11 +245,11 @@ ol.course-tabs li a {
     background-color: #f0f0f0;
 }
 
-div.course-wrapper {
+div.zim-course-wrapper {
     position: relative;
 }
 
-.container > div {
+.zim-container > div {
     table-layout: fixed;
     width: 100%;
     border-radius: 3px;
@@ -259,7 +259,7 @@ div.course-wrapper {
     box-shadow: 0 1px 2px rgba(0,0,0,0.05);
 */
 }
-.course-index {
+.zim-course-index {
     transition: all 0.2s cubic-bezier(0.455, 0.03, 0.515, 0.955) 0s;
     border-right: 1px solid #c8c8c8;
     border-top-left-radius: 3px;
@@ -269,7 +269,7 @@ div.course-wrapper {
     display: table-cell;
 }
 
-.course-index .accordion .course-navigation .button-chapter {
+.zim-course-index .zim-accordion .zim-course-navigation .zim-button-chapter {
     transition: all 3s ease-in-out;
     box-sizing: border-box;
     background-color: rgba(255,255,255,0.5);
@@ -286,13 +286,13 @@ div.course-wrapper {
     cursor:pointer;
 }
 
-.course-index .accordion .course-navigation .chapter-content-container .chapter-menu .menu-item {
+.zim-course-index .zim-accordion .zim-course-navigation .zim-chapter-content-container .zim-chapter-menu .zim-menu-item {
       margin: 4px 0;
       background: inherit;
       font-weight:600;
 
 }
-.course-index .accordion .course-navigation .button-chapter .group-heading {
+.zim-course-index .zim-accordion .zim-course-navigation .zim-button-chapter .zim-group-heading {
     position: relative;
     display: block;
     padding: 15px 0;
@@ -303,7 +303,7 @@ div.course-wrapper {
     text-align: left;
 }
 
-.course-index .accordion .course-navigation .button-chapter .group-heading .icon {
+.zim-course-index .zim-accordion .zim-course-navigation .zim-button-chapter .zim-group-heading .icon {
     position: absolute;
     left: 20px;
     top: 20px;
@@ -311,75 +311,75 @@ div.course-wrapper {
     color: #c8c8c8;
 }
 
-.course-index .accordion .course-navigation .chapter-content-container {
+.zim-course-index .zim-accordion .zim-course-navigation .zim-chapter-content-container {
       background: #fff;
 }
 
-.course-index .accordion .course-navigation .chapter-content-container .chapter-menu {
+.zim-course-index .zim-accordion .zim-course-navigation .zim-chapter-content-container .zim-chapter-menu {
 /*    display: none;*/
     padding: 0 14px;
     overflow: hidden;
 }
-.course-index .accordion .course-navigation .chapter-content-container .chapter-menu .menu-item {
+.zim-course-index .zim-accordion .zim-course-navigation .zim-chapter-content-container .zim-chapter-menu .zim-menu-item {
     margin: 4px 0;
     background: inherit;
 }
-.course-index .accordion .course-navigation .chapter-content-container .chapter-menu .menu-item a {
+.zim-course-index .zim-accordion .zim-course-navigation .zim-chapter-content-container .zim-chapter-menu .zim-menu-item a {
     position: relative;
     display: block;
     padding: 5px 10px;
     border-radius: 5px;
     color: #3c3c3c;
 }
-.course-index .accordion .course-navigation .chapter-content-container .chapter-menu .menu-item.active a {
+.zim-course-index .zim-accordion .zim-course-navigation .zim-chapter-content-container .zim-chapter-menu .zim-menu-item.zim-active a {
     background: #e3e3e3;
 }
-.btn-link, .proctored_exam_status .exam-timer .exam-button-turn-in-exam, .course-index .accordion .course-navigation .chapter-content-container .chapter-menu .menu-item a {
+.btn-link, .proctored_exam_status .exam-timer .exam-button-turn-in-exam, .zim-course-index .accordion .zim-course-navigation .zim-chapter-content-container .zim-chapter-menu .zim-menu-item a {
     font-size: 14px;
     line-height: 20.72px;
 }
-div.course-wrapper section.course-content {
+div.zim-course-wrapper section.zim-course-content {
     padding: 40px 3%;
     line-height: 1.6;
 }
-.content, div.course-wrapper section.course-content, div.info-wrapper section.updates, div.book-wrapper .book, .profile-wrapper .course-info, div.gradebook-wrapper section.gradebook-content, .view-student-notes .wrapper-student-notes .student-notes, .instructor-dashboard-wrapper section.instructor-dashboard-content, .instructor-dashboard-content-2 {
+.content, div.zim-course-wrapper section.zim-course-content, div.zim-info-wrapper section.zim-updates, div.zim-book-wrapper .zim-book, .profile-wrapper .course-info, div.gradebook-wrapper section.gradebook-content, .view-student-notes .wrapper-student-notes .student-notes, .instructor-dashboard-wrapper section.instructor-dashboard-content, .instructor-dashboard-content-2 {
     box-sizing: border-box;
     display: table-cell;
     padding: 2em 2.5em;
     vertical-align: top;
     width: 76.27119%;
 }
-.course-content {
+.zim-course-content {
     margin-top: 30px;
     max-width:100%;
 }
-div.course-wrapper section.course-content .xblock {
+div.zim-course-wrapper section.zim-course-content .xblock {
     overflow-wrap: break-word;
     word-wrap: break-word;
     word-break: break-word;
 }
-div.course-wrapper section.course-content {
+div.zim-course-wrapper section.zim-course-content {
     line-height: 1.6;
 }
 
 
-.xmodule_display.xmodule_SequenceModule .sequence-nav {
+.xmodule_display.xmodule_SequenceModule .zim-sequence-nav {
     margin: -4px 0 30px;
     position: relative;
     border-bottom: none;
     z-index: 0;
 }
-.xmodule_display.xmodule_SequenceModule .sequence-nav-button.disabled {
+.xmodule_display.xmodule_SequenceModule .zim-sequence-nav-button.disabled {
     cursor: normal;
 }
-.xmodule_display.xmodule_SequenceModule .sequence-nav-button.button-previous {
+.xmodule_display.xmodule_SequenceModule .zim-sequence-nav-button.button-previous {
     border-top-left-radius: 35px;
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
     border-bottom-left-radius: 35px;
     left: 0;
 }
-.xmodule_display.xmodule_SequenceModule .sequence-nav-button {
+.xmodule_display.xmodule_SequenceModule .zim-sequence-nav-button {
     transition: all 0.2s cubic-bezier(0.455, 0.03, 0.515, 0.955) 0s;
     position: absolute;
     display: block;
@@ -388,7 +388,7 @@ div.course-wrapper section.course-content {
     height: 46px;
     padding: 0;
 }
-.nav-utilities, .xmodule_display.xmodule_CourseModule .sequence-nav-button, .xmodule_display.xmodule_VideoModule .a11y-menu-container .a11y-menu-list, .xmodule_display.xmodule_VideoModule .video .video-pre-roll, .xmodule_display.xmodule_SequenceModule .sequence-nav-button, .modal-backdrop {
+.nav-utilities, .xmodule_display.xmodule_CourseModule .zim-sequence-nav-button, .xmodule_display.xmodule_VideoModule .a11y-menu-container .a11y-menu-list, .xmodule_display.xmodule_VideoModule .video .video-pre-roll, .xmodule_display.xmodule_SequenceModule .zim-sequence-nav-button, .modal-backdrop {
     z-index: 1000;
 }
 .light-button:disabled, div.history-controls input[type="submit"]:disabled, a.light-button:disabled, .gray-button:disabled, body .xmodule_display.xmodule_CapaModule div.problem .action .save:disabled, input[type="reset"]:disabled, input[type="submit"]:disabled, input[type="button"]:disabled, button:disabled, .button:disabled, .xmodule_display.xmodule_LTIModule div.lti .wrapper-lti-link .lti-link .link_lti_new_window:disabled {
@@ -439,7 +439,7 @@ button[disabled], input[disabled] {
     background-clip: padding-box;
     font-size: 0.8125em;
 }
-.xmodule_display.xmodule_SequenceModule .sequence-nav .sequence-list-wrapper {
+.xmodule_display.xmodule_SequenceModule .zim-sequence-nav .zim-sequence-list-wrapper {
     background-color: #ddd;
     background-image: linear-gradient(to bottom,#ddd,#eee);
     position: relative;
@@ -456,10 +456,10 @@ button[disabled], input[disabled] {
 }
 
 
-.help-tab, .xmodule_display.xmodule_CourseModule .sequence-nav .sequence-list-wrapper, .xmodule_display.xmodule_CourseModule .sequence-nav ol li a p, .xmodule_display.xmodule_SequenceModule .sequence-nav .sequence-list-wrapper, .xmodule_display.xmodule_SequenceModule .sequence-nav ol li a p, div.timer-main, .view-teams .team-profile .page-content-secondary .member-profile p {
+.help-tab, .xmodule_display.xmodule_CourseModule .zim-sequence-nav .zim-sequence-list-wrapper, .xmodule_display.xmodule_CourseModule .zim-sequence-nav ol li a p, .xmodule_display.xmodule_SequenceModule .zim-sequence-nav .zim-sequence-list-wrapper, .xmodule_display.xmodule_SequenceModule .zim-sequence-nav ol li a p, div.timer-main, .view-teams .team-profile .page-content-secondary .member-profile p {
     z-index: 100;
 }
-.xmodule_display.xmodule_SequenceModule .sequence-nav ol {
+.xmodule_display.xmodule_SequenceModule .zim-sequence-nav ol {
     position: absolute;
     top: 0;
     left: 0;
@@ -470,17 +470,17 @@ button[disabled], input[disabled] {
 /*    padding: 0 10px;*/
     width: 100%;
 }
-.xmodule_display.xmodule_SequenceModule .sequence-nav ol li {
+.xmodule_display.xmodule_SequenceModule .zim-sequence-nav ol li {
     display: table-cell;
     min-width: 20px;
 }
-.xmodule_display.xmodule_SequenceModule .sequence-nav ol li a.active {
+.xmodule_display.xmodule_SequenceModule .zim-sequence-nav ol li a.zim-active {
     background-color: #fff;
 }
-.xmodule_display.xmodule_CourseModule .sequence-nav ol li a.active, .xmodule_display.xmodule_CapaModule div.problem .CodeMirror pre.CodeMirror-cursor, .xmodule_display.xmodule_VideoModule .video .video-wrapper .video-controls .secondary-controls .menu-container .menu, .xmodule_display.xmodule_VideoModule .video .video-wrapper .video-controls .secondary-controls .volume .volume-slider-container, .xmodule_display.xmodule_ConditionalModule div.problem .CodeMirror pre.CodeMirror-cursor, .xmodule_display.xmodule_SequenceModule .sequence-nav ol li a.active, .edx-notes-wrapper .annotator-editor .annotator-controls, .instructor-dashboard-wrapper-2 section.idash-section#cohort_management .wrapper-tabs {
+.xmodule_display.xmodule_CourseModule .zim-sequence-nav ol li a.zim-active, .xmodule_display.xmodule_CapaModule div.problem .CodeMirror pre.CodeMirror-cursor, .xmodule_display.xmodule_VideoModule .video .video-wrapper .video-controls .secondary-controls .menu-container .menu, .xmodule_display.xmodule_VideoModule .video .video-wrapper .video-controls .secondary-controls .volume .volume-slider-container, .xmodule_display.xmodule_ConditionalModule div.problem .CodeMirror pre.CodeMirror-cursor, .xmodule_display.xmodule_SequenceModule .zim-sequence-nav ol li a.zim-active, .edx-notes-wrapper .annotator-editor .annotator-controls, .instructor-dashboard-wrapper-2 section.idash-section#cohort_management .wrapper-tabs {
     z-index: 10;
 }
-.xmodule_display.xmodule_SequenceModule .sequence-nav ol li a {
+.xmodule_display.xmodule_SequenceModule .zim-sequence-nav ol li a {
     transition: none;
     width: 100%;
     height: 42px;
@@ -493,12 +493,12 @@ button[disabled], input[disabled] {
     position: relative;
     text-align: center;
 }
-.xmodule_display.xmodule_SequenceModule .sequence-nav ol li a .icon {
+.xmodule_display.xmodule_SequenceModule .zim-sequence-nav ol li a .icon {
     line-height: 42px;
     font-size: 90%;
     color: #0a0a0a;
 }
-.xmodule_display.xmodule_SequenceModule .sequence-nav ol li a p {
+.xmodule_display.xmodule_SequenceModule .zim-sequence-nav ol li a p {
     background: #333;
     color: #fff;
     line-height: 1.41575em;
@@ -513,11 +513,11 @@ button[disabled], input[disabled] {
     visibility: hidden;
     pointer-events: none;
 }
-.help-tab, .xmodule_display.xmodule_CourseModule .sequence-nav .sequence-list-wrapper, .xmodule_display.xmodule_CourseModule .sequence-nav ol li a p, .xmodule_display.xmodule_SequenceModule .sequence-nav .sequence-list-wrapper, .xmodule_display.xmodule_SequenceModule .sequence-nav ol li a p, div.timer-main, .view-teams .team-profile .page-content-secondary .member-profile p {
+.help-tab, .xmodule_display.xmodule_CourseModule .zim-sequence-nav .zim-sequence-list-wrapper, .xmodule_display.xmodule_CourseModule .zim-sequence-nav ol li a p, .xmodule_display.xmodule_SequenceModule .zim-sequence-nav .zim-sequence-list-wrapper, .xmodule_display.xmodule_SequenceModule .zim-sequence-nav ol li a p, div.timer-main, .view-teams .team-profile .page-content-secondary .member-profile p {
     z-index: 100;
 }
 /*
-div.course-wrapper section.course-content p {
+div.zim-course-wrapper section.zim-course-content p {
     margin-bottom: 1.41575em;
 }*/
 .left-shadow {
@@ -542,25 +542,25 @@ div.course-wrapper section.course-content p {
     background-color: transparent;
     pointer-events: none;
 }
-.xmodule_display.xmodule_SequenceModule .sequence-nav-button.button-next {
+.xmodule_display.xmodule_SequenceModule .zim-sequence-nav-button.button-next {
     border-top-left-radius: 0;
     border-top-right-radius: 35px;
     border-bottom-right-radius: 35px;
     border-bottom-left-radius: 0;
     right: 0;
 }
-div.course-wrapper section.course-content .vert-mod {
+div.zim-course-wrapper section.zim-course-content .vert-mod {
     padding: 0;
     margin: 0;
     line-height: 1.4;
     list-style: none;
 }
-div.course-wrapper section.course-content .vert-mod > div:last-child {
+div.zim-course-wrapper section.zim-course-content .vert-mod > div:last-child {
     border-bottom: none;
     margin-bottom: 0;
     padding-bottom: 0;
 }
-div.course-wrapper section.course-content .vert-mod .vert > .xblock-student_view {
+div.zim-course-wrapper section.zim-course-content .vert-mod .vert > .xblock-student_view {
     border-bottom: 1px solid #ddd;
     margin-bottom: 15px;
     padding: 0 0 15px;
@@ -580,14 +580,14 @@ div.course-wrapper section.course-content .vert-mod .vert > .xblock-student_view
     padding: 5px 0;
     color: #5e5e5e;
 }
-.xmodule_display.xmodule_SequenceModule nav.sequence-bottom {
+.xmodule_display.xmodule_SequenceModule nav.zim-sequence-bottom {
     position: relative;
     width: 79px;
     height: 1px;
     margin: 2.8315em auto;
     text-align: center;
 }
-nav.sequence-bottom {
+nav.zim-sequence-bottom {
     position: relative;
     width: 79px;
     height: 1px;
@@ -595,31 +595,31 @@ nav.sequence-bottom {
     text-align: center;
 }
 
-.window-wrap {
+.zim-window-wrap {
     display: flex;
     min-height: 100%;
     flex-direction: column;
     background-color:#f0f0f0;
 }
-body.view-in-course .info-wrapper {
+body.view-in-course .zim-info-wrapper {
     max-width: 1180px;
     margin: 0 auto;
 }
-div.info-wrapper section.updates {
+div.zim-info-wrapper section.zim-updates {
     line-height: 1.41575em;
 }
-div.info-wrapper section.updates > ol, div.info-wrapper section.updates section {
+div.zim-info-wrapper section.zim-updates > ol, div.zim-info-wrapper section.zim-updates section {
     list-style: none;
     margin-bottom: 1.41575em;
     padding-left: 30px;
 }
-div.info-wrapper section.updates > ol > li, div.info-wrapper section.updates > ol article, div.info-wrapper section.updates section > li, div.info-wrapper section.updates section article {
+div.zim-info-wrapper section.zim-updates > ol > li, div.zim-info-wrapper section.zim-updates > ol article, div.zim-info-wrapper section.zim-updates section > li, div.zim-info-wrapper section.zim-updates section article {
     border-bottom: 1px solid rgba(177,177,177,0.32);
     list-style-type: none;
     margin-bottom: 2.12363em;
     padding-bottom: 1.06181em;
 }
-div.info-wrapper section.handouts {
+div.zim-info-wrapper section.handouts {
     padding: 20px 30px;
     padding-left: 30px;
     margin: 0;
@@ -628,7 +628,7 @@ div.info-wrapper section.handouts {
     box-shadow: none;
     font-size: 14px;
 }
-.sidebar, div#wiki_panel, div.info-wrapper section.handouts, div.book-wrapper section.book-sidebar, .profile-wrapper .user-info {
+.sidebar, div#wiki_panel, div.zim-info-wrapper section.handouts, div.zim-book-wrapper section.zim-book-sidebar, .profile-wrapper .user-info {
     box-sizing: border-box;
     display: table-cell;
     font-family: "Droid Arabic Naskh","Open Sans",sans-serif;
@@ -644,13 +644,13 @@ div.info-wrapper section.handouts {
     list-style: none;
 }
 
-div.info-wrapper section.updates > ol > li h2, div.info-wrapper section.updates > ol article h2, div.info-wrapper section.updates section > li h2, div.info-wrapper section.updates section article h2 {
+div.zim-info-wrapper section.zim-updates > ol > li h2, div.zim-info-wrapper section.zim-updates > ol article h2, div.zim-info-wrapper section.zim-updates section > li h2, div.zim-info-wrapper section.zim-updates section article h2 {
     font-size: 0.875em;
     font-weight: bold;
     padding-left: 20px;
 }
 
-.topmobilebar{
+.zim-topmobilebar{
     display:none;
     background-color:#f0f0f0;
 }
@@ -1065,10 +1065,10 @@ div.info-wrapper section.updates > ol > li h2, div.info-wrapper section.updates 
     background: transparent;
     box-shadow: none;
 }
-.course-wrapper{
+.zim-course-wrapper{
   background-color:#ffffff;
 }
-.course-wrapper .course-content .xblock, .course-wrapper .courseware-results-wrapper .xblock {
+.zim-course-wrapper .zim-course-content .xblock, .zim-course-wrapper .courseware-results-wrapper .xblock {
     overflow-wrap: break-word;
     word-wrap: break-word;
     word-break: break-word;
@@ -1116,7 +1116,7 @@ div.info-wrapper section.updates > ol > li h2, div.info-wrapper section.updates 
     border: 1px solid #d9d9d9;
     border-radius: 3px;
 }
-.list_course{
+.zim-list_course{
   background-color:#ffffff;
   width:auto;
   box-sizing: border-box;
@@ -1225,12 +1225,12 @@ fieldset{
     font-size: 16px;
     font-weight: 600;
 }
-div.book-wrapper {
+div.zim-book-wrapper {
     max-width: 1150px;
     margin: 0 auto;
     width: 100%;
 }
-div.book-wrapper section.book-sidebar {
+div.zim-book-wrapper section.zim-book-sidebar {
     box-sizing: border-box;
     padding: 10px 0;
     border-radius: 3px 0 0 3px;
@@ -1241,7 +1241,7 @@ div.book-wrapper section.book-sidebar {
     border-right: none;
     width: 180px;
 }
-.sidebar, div#wiki_panel, div.info-wrapper section.handouts, div.book-wrapper section.book-sidebar, .profile-wrapper .user-info {
+.sidebar, div#wiki_panel, div.zim-info-wrapper section.handouts, div.zim-book-wrapper section.zim-book-sidebar, .profile-wrapper .user-info {
     box-sizing: border-box;
     display: table-cell;
     font-family: "Source Sans Pro","Open Sans",Verdana,Geneva,sans-serif,sans-serif;
@@ -1251,41 +1251,41 @@ div.book-wrapper section.book-sidebar {
     width: 23.72881%;
     background: #FBFFFD;
 }
-#booknav {
+#zim-booknav {
     list-style: none;
 }
-.sidebar ul, div#wiki_panel ul, div.info-wrapper section.handouts ul, div.book-wrapper section.book-sidebar ul, .profile-wrapper .user-info ul, .sidebar ol, div#wiki_panel ol, div.info-wrapper section.handouts ol, div.book-wrapper section.book-sidebar ol, .profile-wrapper .user-info ol {
+.sidebar ul, div#wiki_panel ul, div.zim-info-wrapper section.handouts ul, div.zim-book-wrapper section.zim-book-sidebar ul, .profile-wrapper .user-info ul, .sidebar ol, div#wiki_panel ol, div.zim-info-wrapper section.handouts ol, div.zim-book-wrapper section.zim-book-sidebar ol, .profile-wrapper .user-info ol {
     margin: 0;
     padding-left: 0;
 }
-div.book-wrapper section.book-sidebar #booknav > li {
+div.zim-book-wrapper section.zim-book-sidebar #zim-booknav > li {
     padding: 5px 6px;
     margin: 5px 10px;
 }
-div.book-wrapper section.book-sidebar #booknav li {
+div.zim-book-wrapper section.zim-book-sidebar #zim-booknav li {
     background: none;
     border-bottom: 0;
     padding-left: 10px;
 }
-div.book-wrapper section.book-sidebar #booknav .chapter {
+div.zim-book-wrapper section.zim-book-sidebar #zim-booknav .zim-chapter {
     line-height: 1.4em;
 }
-div.book-wrapper section.book-sidebar #booknav li a {
+div.zim-book-wrapper section.zim-book-sidebar #zim-booknav li a {
     padding: 0;
     color: #4F7573;
 }
-.sidebar ul li a, div#wiki_panel ul li a, div.info-wrapper section.handouts ul li a, div.book-wrapper section.book-sidebar ul li a, .profile-wrapper .user-info ul li a, .sidebar ol li a, div#wiki_panel ol li a, div.info-wrapper section.handouts ol li a, div.book-wrapper section.book-sidebar ol li a, .profile-wrapper .user-info ol li a {
+.sidebar ul li a, div#wiki_panel ul li a, div.zim-info-wrapper section.handouts ul li a, div.zim-book-wrapper section.zim-book-sidebar ul li a, .profile-wrapper .user-info ul li a, .sidebar ol li a, div#wiki_panel ol li a, div.zim-info-wrapper section.handouts ol li a, div.zim-book-wrapper section.zim-book-sidebar ol li a, .profile-wrapper .user-info ol li a {
     display: block;
     line-height: 1.41575em;
     font-size: 1em;
     box-sizing: border-box;
     padding: 0.35394em 0.70788em 0.35394em 0;
 }
-.sidebar a, div#wiki_panel a, div.info-wrapper section.handouts a, div.book-wrapper section.book-sidebar a, .profile-wrapper .user-info a {
+.sidebar a, div#wiki_panel a, div.zim-info-wrapper section.handouts a, div.zim-book-wrapper section.zim-book-sidebar a, .profile-wrapper .user-info a {
     border: none;
     font-style: normal;
 }
-div.book-wrapper .book {
+div.zim-book-wrapper .zim-book {
     padding: 0;
     width: 76%;
 }
@@ -1298,7 +1298,7 @@ div.book-wrapper .book {
     margin-top: 15px;
     color: #494949;
 }
-#course-content{
+#zim-course-content{
 	width:100%;
 }
 
@@ -1341,10 +1341,10 @@ div.book-wrapper .book {
 
 
 @media (max-width: 640px) {
-  .course-index, .courseware{
+  .zim-course-index, .zim-courseware{
     display:none;
   }
-  section.updates {
+  section.zim-updates {
     box-sizing: border-box;
     display: block;
     padding: 1em 1em;
@@ -1357,12 +1357,12 @@ div.book-wrapper .book {
     width: 50%;
   }
 
-  div.course-wrapper section.course-content {
+  div.zim-course-wrapper section.zim-course-content {
 	display: block;
 	width:100%;
 	max-width:100%;
   }
-  #course-content{
+  #zim-course-content{
     padding:2em 0.5em;
   }
   .topmobilebar{
@@ -1372,19 +1372,19 @@ div.book-wrapper .book {
     margin:5px 0;
     font-size: 28px;
   }
-  #show_pagemobilemenu {
+  #zim-show_pagemobilemenu {
     padding: 0.3em;
   }
-  #show_sidemenu{
+  #zim-show_sidemenu{
     padding: 0.3em;
   }
-  .course-index{
+  .zim-course-index{
     width:100%;
     position:sticky;
     z-index:1;
 
   }
-  ol.course-tabs li {
+  ol.zim-course-tabs li {
     text-align:center;
     width:100;
     position:sticky;
@@ -1408,7 +1408,7 @@ div.book-wrapper .book {
   .page-content {
       padding: 8px;
   }
-  .book{
+  .zim-book{
       display:none;
   }
 }

--- a/openedx2zim/templates/base.html
+++ b/openedx2zim/templates/base.html
@@ -20,24 +20,24 @@
     <script type="text/javascript" src="{{ rooturl }}assets/mooc.js"></script>
   </head>
   <body class="{% block bodyclass %}{% endblock %}">
-    <div class="topmobilebar">
+    <div class="zim-topmobilebar">
       {% if side_menu or forum_menu %}
-        <a onclick="{% if side_menu %}show_sidemenu(){% else %}show_forum_menu(){% endif %}" id="show_sidemenu">
+        <a onclick="{% if side_menu %}show_sidemenu(){% else %}show_forum_menu(){% endif %}" id="zim-show_sidemenu">
           <i class="fa fa-bars"></i>
         </a>
       {% endif %}
-      <a onclick="show_pagemobilemenu()" id="show_pagemobilemenu">
+      <a onclick="show_pagemobilemenu()" id="zim-show_pagemobilemenu">
         <i class="fa fa-angle-down"></i>
       </a>
     </div>
-  <div class="window-wrap">
-    <div id="content" class="content-wrapper">
-      <nav class="courseware wrapper-course-material" aria-label="Course Material">
-        <div class="course-material">
-          <ol class="course-tabs">
+  <div class="zim-window-wrap">
+    <div id="content" class="zim-content-wrapper">
+      <nav class="zim-courseware zim-wrapper-course-material" aria-label="Course Material">
+        <div class="zim-course-material">
+          <ol class="zim-course-tabs">
             {% for elem_name in mooc.course_tabs %}
                 {% if (mooc.course_tabs[elem_name] != "/index.html" and mooc.course_tabs[elem_name] | clean_top in output_path) or (mooc.course_tabs[elem_name] == "/index.html" and render_homepage) %}
-                  <li><a class="active" href="{{ rooturl }}{{ mooc.course_tabs[elem_name] }}">{{ elem_name }}</a></li>
+                  <li><a class="zim-active" href="{{ rooturl }}{{ mooc.course_tabs[elem_name] }}">{{ elem_name }}</a></li>
                 {% else %}
                   <li><a href="{{ rooturl }}{{ mooc.course_tabs[elem_name] }}">{{ elem_name }}</a></li>
                 {% endif %}
@@ -48,6 +48,7 @@
         {% block body %}{% endblock %}
    </div>
     </div>
+    {% block body_scripts %}{% endblock %}
     <script>
       window.MathJax = {
         tex: {

--- a/openedx2zim/templates/booknav.html
+++ b/openedx2zim/templates/booknav.html
@@ -5,19 +5,19 @@
 {% block title %} Textbook {% endblock %}
 
 {% block body %}
-<div class="container">
-<main id="main" aria-label="Content" tabindex="-1">
-<div class="book-wrapper">
-    <section class="book-sidebar" aria-label="Textbook Navigation">
-	    <ul id="booknav">
+<div class="zim-container">
+<main id="zim-main" aria-label="Content" tabindex="-1">
+<div class="zim-book-wrapper">
+    <section class="zim-book-sidebar" aria-label="Textbook Navigation">
+	    <ul id="zim-booknav">
 	    {% for book in book_list %}
 		  <li>
-		    <a class="chapter" rel="{{ book["url"] }}" href="{{ rooturl }}{{ dir_path }}/{{ book["url"] }}" onclick="return booknav_change(this)"> {{ book["name"] }}</a>
+		    <a class="zim-chapter" rel="{{ book["url"] }}" href="{{ rooturl }}{{ dir_path }}/{{ book["url"] }}" onclick="return booknav_change(this)"> {{ book["name"] }}</a>
 		  </li>
 	    {% endfor %}
 	    </ul>
     </section>
-    <div class="book">
+    <div class="zim-book">
 	    <iframe
 	    title="{{ book_list[0]["name"] }}"
 	    id="viewer-frame"

--- a/openedx2zim/templates/chapter_menu.html
+++ b/openedx2zim/templates/chapter_menu.html
@@ -5,8 +5,8 @@
 {% block title %}{{ chapter.display_name }}{% endblock %}
 
 {% block body %}
-<div class="container">
-  <div class="list_course">
+<div class="zim-container">
+  <div class="zim-list_course">
     <ul>
       {% for sequential in chapter.descendants %}
         {% if sequential.descendants|length > 0 %}

--- a/openedx2zim/templates/course_menu.html
+++ b/openedx2zim/templates/course_menu.html
@@ -5,8 +5,8 @@
 {% block title %}{{ course.display_name }}{% endblock %}
 
 {% block body %}
-<div class="container">
-  <div class="course-wrapper" role="presentation">
+<div class="zim-container">
+  <div class="zim-course-wrapper" role="presentation">
 	{% include "side_menu.html" %}
   </div>
 </div>

--- a/openedx2zim/templates/home.html
+++ b/openedx2zim/templates/home.html
@@ -5,9 +5,9 @@
 {% block title %}{{ mooc.head_course_xblock.display_name }}{% endblock %}
 
 {% block body %}
-  <section class="container">
-    <div class="info-wrapper">
-      <section class="updates">
+  <section class="zim-container">
+    <div class="zim-info-wrapper">
+      <section class="zim-updates">
         <h1> {{ mooc.head_course_xblock.display_name }} </h1>
         <section>
           {% for message  in messages %}

--- a/openedx2zim/templates/side_menu.html
+++ b/openedx2zim/templates/side_menu.html
@@ -1,31 +1,31 @@
-<div class="course-index" {% if display_on_mobile %} style="display:block" {% endif %}>
-  <div class="accordion">
-    <nav class="course-navigation" aria-label="Course">
+<div class="zim-course-index" {% if display_on_mobile %} style="display:block" {% endif %}>
+  <div class="zim-accordion">
+    <nav class="zim-course-navigation" aria-label="Course">
     {% for chapter_ in mooc.head_course_xblock.descendants %}
       {% if chapter_.descendants|length > 0 %}
 <!--        <li>-->
           {% if chapter and chapter_.id == chapter.id  or all_side_menu_open %}
-            <a class="button-chapter chapter active" role="button" aria-expanded="true" onclick='toggle_visibility_submenu(this)'>
-              <span class="group-heading active" aria-label="{{ chapter_.display_name }}">
+            <a class="zim-button-chapter chapter zim-active" role="button" aria-expanded="true" onclick='toggle_visibility_submenu(this)'>
+              <span class="zim-group-heading zim-active" aria-label="{{ chapter_.display_name }}">
                 <span class="icon fa fa-caret-down" aria-hidden="true"></span>
                 {{ chapter_.display_name }}
               </span>
             </a>
-            <div class="chapter-content-container" {#" is-open" tabindex="-1" #} role="group" aria-label="{{ chapter_.display_name }} submenu" style="display:block;">
+            <div class="zim-chapter-content-container" {#" is-open" tabindex="-1" #} role="group" aria-label="{{ chapter_.display_name }} submenu" style="display:block;">
             {% else %}
-            <a class="button-chapter chapter" role="button" aria-expanded="false" onclick='toggle_visibility_submenu(this)'>
-              <span class="group-heading" aria-label="{{ chapter_.display_name }}">
+            <a class="zim-button-chapter chapter" role="button" aria-expanded="false" onclick='toggle_visibility_submenu(this)'>
+              <span class="zim-group-heading" aria-label="{{ chapter_.display_name }}">
                 <span class="icon fa fa-caret-right" aria-hidden="true"></span>
                 {{ chapter_.display_name }}
               </span>
             </a>
-            <div class="chapter-content-container" {#" is-open" tabindex="-1" #} role="group" aria-label="{{ chapter_.display_name }} submenu" style="display:none;">
+            <div class="zim-chapter-content-container" {#" is-open" tabindex="-1" #} role="group" aria-label="{{ chapter_.display_name }} submenu" style="display:none;">
             {% endif %}
-            <div class="chapter-menu">
+            <div class="zim-chapter-menu">
           {% for sequential_ in chapter_.descendants %}
             {% if sequential_.descendants|length > 0 %}
               {% if sequential and sequential_.id == sequential.id %}
-                <div class="menu-item active">
+                <div class="zim-menu-item zim-active">
                   <a href="{{ rooturl }}{{ sequential_.descendants[0].relative_path }}/index.html" >
                     <p>
                       {{ sequential_.display_name }}
@@ -34,7 +34,7 @@
                   </a>
                 </div>
               {% else %}
-                <div class="menu-item">
+                <div class="zim-menu-item">
                   <a href="{{ rooturl }}{{ sequential_.descendants[0].relative_path }}/index.html" >
                     <p>
                       {{ sequential_.display_name }}

--- a/openedx2zim/templates/vertical.html
+++ b/openedx2zim/templates/vertical.html
@@ -1,26 +1,35 @@
 {% extends "base.html" %}
 
-{% block addhead %} <script type="text/javascript" src="{{ rooturl }}assets/xblocks.js"></script> {% endblock %}
+{% block title %}
+{{ vertical.display_name }}
+{% endblock %}
 
-{% block bodyclass %}vertical{% endblock %}
+{% block addhead %}
+<script type="text/javascript" src="{{ rooturl }}assets/xblocks.js"></script>
+{% for header_element in extra_headers %}
+{{ header_element }}
+{% endfor %}
+{% endblock %}
 
-{% block title %}{{ vertical.display_name }}{% endblock %}
+{% block bodyclass %}
+vertical
+{% endblock %}
 
 {% block body %}
-<div class="container">
-  <div class="course-wrapper" role="presentation">
+<div class="zim-container">
+  <div class="zim-course-wrapper" role="presentation">
     {% if side_menu %}
         {% include "side_menu.html" %}
     {% endif %}
-    <section id="course-content" class="course-content" role="main" aria-label="Content">
+    <section id="course-content" class="zim-course-content" role="main" aria-label="Content">
       <div class="xblock xblock-student_view xblock-student_view-sequential xmodule_display xmodule_SequenceModule xblock-initialized" data-runtime-class="LmsRuntime" data-init="XBlockToXModuleShim" data-block-type="sequential" data-usage-id="{{ vertical.xblock_json["id"] }}" data-type="Sequence" data-course-id="{{ mooc.course_id }}">
         <div id="sequence_{{ extracted_id }}" class="sequence" data-id="{{ vertical.xblock_json["id"] }}" data-position="1">
-          <div class="sequence-nav">
+          <div class="zim-sequence-nav">
               {% if prev_vertical %}
               <a href="{{ rooturl }}{{ prev_vertical.relative_path }}/index.html" title="{{ prev_vertical.display_name }}">
-                <button class="sequence-nav-button button-previous">
+                <button class="zim-sequence-nav-button button-previous">
               {% else %}
-                <button class="sequence-nav-button button-previous deactivated">
+                <button class="zim-sequence-nav-button button-previous deactivated">
               {% endif %}
                   <i class="icon fa fa-chevron-left" aria-hidden="true"></i>
                   <span class="sr">Previous</span>
@@ -28,8 +37,8 @@
               {% if prev_vertical %}
               </a>
 	      {% endif %}
-            <nav class="sequence-list-wrapper" aria-label="Sequence">
-              <ol id="sequence-list" role="tablist">
+            <nav class="zim-sequence-list-wrapper" aria-label="Sequence">
+              <ol id="zim-sequence-list" role="tablist">
               {% for vertical_ in sequential.descendants %}
                 <li {% if vertical_.id == vertical.id %} class="current_vertical" {% endif %}>
                   <a id="tab_0" tabindex=0 data-id="{{ vertical_.xblock_json["id"] }}" data-page-title="{{ vertical_.display_name }}" href="{{ rooturl }}{{ vertical_.relative_path }}/index.html" title="{{ vertical_.display_name }}">
@@ -47,9 +56,9 @@
             </nav>
                 {% if next_vertical %}
                 <a href="{{ rooturl }}{{ next_vertical.relative_path }}/index.html" title="{{ next_vertical.display_name }}">
-                  <button class="sequence-nav-button button-next">
+                  <button class="zim-sequence-nav-button button-next">
                 {% else %}
-                  <button class="sequence-nav-button button-next deactivated">
+                  <button class="zim-sequence-nav-button button-next deactivated">
                 {% endif %}
                   <span class="icon fa fa-chevron-right" aria-hidden="true"></span>
                   <span class="sr">Next</span>
@@ -59,34 +68,34 @@
 		{% endif %}
           </div>
           <div id="seq_content">
+            <div class="course-wrapper" role="presentation">
+            <section id="course-content" class="course-content" role="main" aria-label="Content">
             <div class="xblock xblock-student_view xblock-student_view-vertical xblock-initialized">
               <h2 class="hd hd-2 unit-title"> {{ vertical.xblock_json["display_name"] }} </h2>
-              {% for elem  in vertical_content %}
-                <div class="vert-mod">
-                  <div class="vert vert-0">
-                    <div class="xblock xblock-student_view xmodule_display xblock-initialized">
-                      {{ elem }}
-                    </div>
-                  </div>
-                </div>
+              <div class="vert-mod">
+              {% for elem in vertical_content %}
+              {{ elem }}
               {% endfor %}
+              </div>
+            </div>
+            </section>
             </div>
           </div>
-          <nav class="sequence-bottom" aria-label="Section">
+          <nav class="zim-sequence-bottom" aria-label="Section">
               <a href="{{ rooturl }}{{ prev_vertical.relative_path }}/index.html" title="{{ prev_vertical.display_name }}">
               {% if prev_vertical %}
-                <button class="sequence-nav-button button-previous">
+                <button class="zim-sequence-nav-button button-previous">
               {% else %}
-                <button class="sequence-nav-button button-previous deactivated">
+                <button class="zim-sequence-nav-button button-previous deactivated">
               {% endif %}
                 <i class="icon fa fa-chevron-left" aria-hidden="true"></i>
               </button>
               </a>
               <a href="{{ rooturl }}{{ next_vertical.relative_path }}/index.html" title="{{ next_vertical.display_name }}">
                 {% if next_vertical %}
-                  <button class="sequence-nav-button button-next">
+                  <button class="zim-sequence-nav-button button-next">
                 {% else %}
-                  <button class="sequence-nav-button button-next deactivated">
+                  <button class="zim-sequence-nav-button button-next deactivated">
                 {% endif %}
                 <i class="icon fa fa-chevron-right" aria-hidden="true"></i>
               </button>
@@ -97,5 +106,10 @@
     </section>
   </div>
 </div>
+{% endblock %}
 
+{% block body_scripts %}
+{% for elem in body_scripts %}
+{{ elem }}
+{% endfor %}
 {% endblock %}

--- a/openedx2zim/templates/vertical.html
+++ b/openedx2zim/templates/vertical.html
@@ -112,4 +112,13 @@ vertical
 {% for elem in body_scripts %}
 {{ elem }}
 {% endfor %}
+<!-- workaround to simulate sequential content change behaviour as some custom JS may depend on this
+     we do this as our seq_content is static (as we have HTML at vertical level) but seq_content on instances 
+     is not static (as they have HTML at sequential level) -->
+<script type="text/javascript">
+  $(window).load(function(){
+    $('#seq_content').append("<div id='dummy_div'></div>");
+    $('#dummy_div').css("display", "none")
+  });
+</script>
 {% endblock %}

--- a/openedx2zim/templates/wiki_list.html
+++ b/openedx2zim/templates/wiki_list.html
@@ -4,7 +4,7 @@
 
 {% block title %} Wiki {% endblock %}
 {% block body %}
-<div class="container">
+<div class="zim-container">
   <div class="wiki-wrapper">
     <main id="main" aria-label="Content" tabindex="-1">
       <section class="wiki " id="wiki-content">

--- a/openedx2zim/xblocks_extractor/html.py
+++ b/openedx2zim/xblocks_extractor/html.py
@@ -19,7 +19,7 @@ class Html(BaseXblock):
         if not content:
             return
         soup = BeautifulSoup(content, "lxml")
-        html_content = soup.find("div", attrs={"class": "edx-notes-wrapper"})
+        html_content = soup.find("div", attrs={"class": "xblock"})
         if not html_content:
             html_content = str(soup.find("div", attrs={"class": "course-wrapper"}))
         self.html = self.scraper.html_processor.dl_dependencies_and_fix_links(

--- a/openedx2zim/xblocks_extractor/problem.py
+++ b/openedx2zim/xblocks_extractor/problem.py
@@ -64,6 +64,11 @@ class Problem(BaseXblock):
             output_path=self.output_path,
             path_from_html=self.folder_name,
         )
+        html_content = self.scraper.html_processor.defer_scripts(
+            content=html_content,
+            output_path=self.output_path,
+            path_from_html=self.folder_name,
+        )
         self.html_content = str(html_content)
 
         # Save json answers

--- a/openedx2zim/xblocks_extractor/vertical.py
+++ b/openedx2zim/xblocks_extractor/vertical.py
@@ -1,5 +1,7 @@
 from .base_xblock import BaseXblock
+from bs4 import BeautifulSoup
 from ..utils import jinja
+import html
 
 
 class Vertical(BaseXblock):
@@ -9,6 +11,9 @@ class Vertical(BaseXblock):
         super().__init__(
             xblock_json, relative_path, root_url, xblock_id, descendants, scraper
         )
+        self.extra_head_content = []
+        self.body_end_scripts = []
+        self.verts = []
 
         # set icon
         if self.xblock_json["block_counts"]["video"] != 0:
@@ -20,26 +25,95 @@ class Vertical(BaseXblock):
         else:
             self.icon_type = "fa-book"
 
+    def remove_head_and_html_tags(self, html_string):
+        """ removes <head> and <html> tags from endpoints of a string """
+        if html_string.startswith("<html>"):
+            html_string = html_string[6:]
+        if html_string.endswith("</html>"):
+            html_string = html_string[:-7]
+        if html_string.startswith("<head>"):
+            html_string = html_string[6:]
+        if html_string.endswith("</head>"):
+            html_string = html_string[:-7]
+        return html_string
+
     def download(self, instance_connection):
+        instance_assets_path = self.scraper.build_dir.joinpath("instance_assets")
+        instance_assets_path.mkdir(parents=True, exist_ok=True)
+
+        # get the LMS content for the vertical
+        content = instance_connection.get_page(self.xblock_json["lms_web_url"])
+        soup = BeautifulSoup(content, "lxml")
+
+        # extract CSS and JS from HTML head
+        html_headers = soup.find("head")
+        head_css_js = (
+            html_headers.find_all("script")
+            + html_headers.find_all("link", attrs={"rel": "stylesheet"})
+            + html_headers.find_all("style")
+        )
+        for header_element in head_css_js:
+            self.extra_head_content.append(
+                self.remove_head_and_html_tags(
+                    self.scraper.html_processor.dl_dependencies_and_fix_links(
+                        content=str(header_element),
+                        output_path=instance_assets_path,
+                        path_from_html=f"{self.root_url}instance_assets",
+                    )
+                )
+            )
+
+        # extract scripts at the end of body
+        html_body = soup.find("body")
+        body_scripts = html_body.find_all("script")
+        for script in body_scripts:
+            self.body_end_scripts.append(
+                self.remove_head_and_html_tags(
+                    self.scraper.html_processor.dl_dependencies_and_fix_links(
+                        content=str(script),
+                        output_path=instance_assets_path,
+                        path_from_html=f"{self.root_url}instance_assets",
+                    )
+                )
+            )
+
+        # download content from descendants
         for x in self.descendants:
             x.download(instance_connection)
+
+        # get divs with class vert as those contain extra CSS classes to be applied at render step
+        seq_contents = soup.find_all("div", attrs={"class": "seq_contents"})
+        for content in seq_contents:
+            unescaped_html = html.unescape(content.string)
+            new_soup = BeautifulSoup(unescaped_html, "lxml")
+            self.verts += new_soup.find_all("div", attrs={"class": "vert"})
 
     def render(self, prev_vertical, next_vertical, chapter, sequential):
         vertical = []
         for x in self.descendants:
-            vertical.append(x.render())
+            extra_vert_classes = []
+            for vert_div in self.verts:
+                if x.xblock_json["id"] == vert_div.attrs["data-id"]:
+                    extra_vert_classes = vert_div.attrs["class"]
+                    extra_vert_classes.remove("vert")
+            start = '<div class="vert ' + " ".join(extra_vert_classes) + '">'
+            end = "</div>"
+            vertical.append(start + x.render() + end)
+
         jinja(
             self.output_path.joinpath("index.html"),
             "vertical.html",
             False,
-            rooturl=self.root_url,
+            vertical_content=vertical,
+            extra_headers=self.extra_head_content,
+            body_scripts=self.body_end_scripts,
+            vertical=self,
             mooc=self.scraper,
             chapter=chapter,
             sequential=sequential,
-            vertical=self,
             extracted_id=self.xblock_json["id"].split("@")[-1],
-            vertical_content=vertical,
             prev_vertical=prev_vertical,
             next_vertical=next_vertical,
             side_menu=True,
+            rooturl=self.root_url,
         )


### PR DESCRIPTION
This addresses #90 and in turn several other issues (Implements the second option as in #90). It basically gets the CSS and JS from the instance to have proper layout.

This has the following changes - 
- This fetches the CSS and JS from the instance at the vertical level
- The CSS for the UI on our side now has prefix `zim-` to prevent complications with the extracted instance CSS
- The CSS dependencies are now downloaded and CSS is rewritten at the CSS download step in html_processor.py
- Templates are changed a bit to allow CSS to be applied properly

At this point of time it fixes #71, #72 (except fonts), #74, #80, #84 
Also, with this, #78 would be a wontfix as we are only extracting CSS at the vertical level. The navigation bar can be made optional though using a parameter

#82 is now fixed. It depended on a MutationObserver observing seq_contents which is not static in the instances (unlike ours). On instances they have HTMLs at sequential level whereas we have it at the vertical level. So, added a small jQuery script to simulate the sequential content change behaviour on loading a HTML.

#79 is now fixed. It was due to an inline script that tried to access a tag below it. This has been solved by deferring the scripts and putting them into a separate file when they're in the body of an xblock.

Currently, the following things are yet to be solved -
- Downloading fonts from imported CSS files (reason for no font fix in #72)
- Having a block list for CSS/JS to not download unnecessary extras - (like there's a cookie message popping up on PHZH)