### PR TITLE
Get CSS recursively from instance

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,6 @@ iso-639==0.4.5
 zimscraperlib>=1.2.1,<1.3
 kiwixstorage>=0.3,<1.0
 pif==0.8.2
+xxhash==2.0.0
 # youtube-dl should be updated as frequently as possible
 youtube_dl


### PR DESCRIPTION
This gets the CSS files recursively from the instance by getting the dependencies from the CSS imported within other CSS using the `@import` keyword. This fixes the fonts with the PHZH instance.

The following changes are introduced to fix #94:
- download_dependencies_from_css() is now responsible for reading and rewriting the CSS content
- It now downloads CSS files recursively
- Filenames are kept as original (in download_and_get_filename()) to avoid complications as far as possible. If a filename cannot be inferred from the URL, a new one is generated by hashlib.