### PR TITLE
Use correct path for favicon in templates

### DIFF
--- a/openedx2zim/templates/base.html
+++ b/openedx2zim/templates/base.html
@@ -6,7 +6,7 @@
     <meta name="generator" content="https://github.com/openzim/openedx/"/>
     <meta name="author" content="kiwix team"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
-    <link id="favicon" rel="shortcut icon" href="{{ rooturl }}/favicon.png" type="image/png">
+    <link id="favicon" rel="shortcut icon" href="{{ rooturl }}favicon.png" type="image/png">
     <link href="{{ rooturl }}assets/main.css" rel="stylesheet" type="text/css" />
     <link href="{{ rooturl }}assets/fontawesome/css/all.css" rel="stylesheet" type="text/css" />
     <link href="{{ rooturl }}assets/videojs/video-js.min.css" rel="stylesheet" type="text/css">


### PR DESCRIPTION
Apparently #99 was due to an extra `/` in the path of the favicon. This fixes it.