### PR TITLE
Make sequential top navigation optional

### DIFF
--- a/openedx2zim/entrypoint.py
+++ b/openedx2zim/entrypoint.py
@@ -121,6 +121,13 @@ def main():
     )
 
     parser.add_argument(
+        "--remove-seq-nav",
+        help="Remove the top sequential navigation bar in the ZIM",
+        action="store_true",
+        default=False,
+    )
+
+    parser.add_argument(
         "--optimization-cache",
         help="URL with credentials and bucket name to S3 Optimization Cache",
         dest="s3_url_with_credentials",

--- a/openedx2zim/scraper.py
+++ b/openedx2zim/scraper.py
@@ -99,6 +99,7 @@ class Openedx2Zim:
         favicon_url,
         add_wiki,
         add_forum,
+        remove_seq_nav,
         s3_url_with_credentials,
         use_any_optimized_version,
         output_dir,
@@ -137,6 +138,7 @@ class Openedx2Zim:
         self.add_forum = add_forum
         self.ignore_missing_xblocks = ignore_missing_xblocks
         self.autoplay = autoplay
+        self.remove_seq_nav = remove_seq_nav
 
         # authentication
         self.email = email

--- a/openedx2zim/templates/vertical.html
+++ b/openedx2zim/templates/vertical.html
@@ -24,6 +24,7 @@ vertical
     <section id="course-content" class="zim-course-content" role="main" aria-label="Content">
       <div class="xblock xblock-student_view xblock-student_view-sequential xmodule_display xmodule_SequenceModule xblock-initialized" data-runtime-class="LmsRuntime" data-init="XBlockToXModuleShim" data-block-type="sequential" data-usage-id="{{ vertical.xblock_json["id"] }}" data-type="Sequence" data-course-id="{{ mooc.course_id }}">
         <div id="sequence_{{ extracted_id }}" class="sequence" data-id="{{ vertical.xblock_json["id"] }}" data-position="1">
+          {% if not remove_seq_nav %}
           <div class="zim-sequence-nav">
               {% if prev_vertical %}
               <a href="{{ rooturl }}{{ prev_vertical.relative_path }}/index.html" title="{{ prev_vertical.display_name }}">
@@ -67,6 +68,7 @@ vertical
                 </a>
 		{% endif %}
           </div>
+          {% endif %}
           <div class="window-wrap">
           <div id="seq_content">
             <div class="course-wrapper" role="presentation">

--- a/openedx2zim/xblocks_extractor/vertical.py
+++ b/openedx2zim/xblocks_extractor/vertical.py
@@ -105,4 +105,5 @@ class Vertical(BaseXblock):
             next_vertical=next_vertical,
             side_menu=True,
             rooturl=self.root_url,
+            remove_seq_nav=self.scraper.remove_seq_nav,
         )


### PR DESCRIPTION
This fixes #78 by making top sequential navigation optional by adding a new parameter `--remove-seq-nav`.
The option is passed to the `vertical.html` template via `vertical.py` and jinja handles the condition.