### PR TITLE
Fix invalid internal links

### DIFF
--- a/openedx2zim/html_processor.py
+++ b/openedx2zim/html_processor.py
@@ -35,10 +35,12 @@ class HtmlProcessor:
             return None, None
         fresh_download = False
         if not output_file.exists():
-            self.scraper.download_file(
+            if self.scraper.download_file(
                 prepare_url(src, self.scraper.instance_url), output_file,
-            )
-            fresh_download = True
+            ):
+                fresh_download = True
+            else:
+                return None, None
         return filename, fresh_download
 
     def download_dependencies_from_css(

--- a/openedx2zim/scraper.py
+++ b/openedx2zim/scraper.py
@@ -292,11 +292,11 @@ class Openedx2Zim:
         book_list = []
         for url in pdf:
             file_name = pathlib.Path(urllib.parse.urlparse(url["rel"][0]).path).name
-            self.download_file(
+            if self.download_file(
                 prepare_url(url["rel"][0], self.instance_url),
                 output_path.joinpath(file_name),
-            )
-            book_list.append({"url": file_name, "name": url.get_text()})
+            ):
+                book_list.append({"url": file_name, "name": url.get_text()})
         return book_list
 
     def annex_extra_page(self, tab_href, tab_org_path):
@@ -644,30 +644,43 @@ class Openedx2Zim:
         return f"{fpath.suffix[1:]}/{safe_url}/{quality}"
 
     def download_file(self, url, fpath):
+        """ downloads a file from the supplied url to the supplied fpath
+            returns true if successful, false if unsuccessful """
+
         is_youtube = "youtube" in url
         downloaded_from_cache = False
         meta, filetype = get_meta_from_url(url)
         if self.s3_storage:
             s3_key = self.generate_s3_key(url, fpath)
             downloaded_from_cache = self.download_from_cache(s3_key, fpath, meta)
-        if not downloaded_from_cache:
+        if downloaded_from_cache:
+            # optimized file downloaded from cache
+            return True
+        else:
+            # file not downloaded from cache
             if is_youtube:
                 downloaded_file = self.download_from_youtube(url, fpath)
             else:
                 downloaded_file = self.downlaod_form_url(url, fpath, filetype)
             if not downloaded_file:
                 logger.error(f"Error while downloading file from URL {url}")
-                return
+                return False
             try:
                 optimized = self.optimize_file(downloaded_file, fpath)
                 if self.s3_storage and optimized:
                     self.upload_to_cache(s3_key, fpath, meta)
             except Exception as exc:
                 logger.error(f"Error while optimizing {fpath}: {exc}")
-                return
+                # clean leftovers if any
+                if downloaded_file.exists():
+                    downloaded_file.unlink()
+                if fpath.exists():
+                    fpath.unlink()
+                return False
             finally:
                 if downloaded_file.resolve() != fpath.resolve() and not fpath.exists():
                     shutil.move(downloaded_file, fpath)
+                return True
 
     def render_booknav(self):
         for book_nav in self.book_lists:

--- a/openedx2zim/xblocks_extractor/drag_and_drop_v2.py
+++ b/openedx2zim/xblocks_extractor/drag_and_drop_v2.py
@@ -31,22 +31,26 @@ class DragAndDropV2(
         # item
         for item in self.content["items"]:
             name = pathlib.Path(item["expandedImageURL"]).name
-            self.scraper.download_file(
+            if self.scraper.download_file(
                 prepare_url(item["expandedImageURL"], self.scraper.instance_url),
                 self.scraper.instance_assets_dir.joinpath(name),
-            )
-            item["expandedImageURL"] = get_back_jumps(5) + f"instance_assets/{name}"
+            ):
+                item["expandedImageURL"] = get_back_jumps(5) + f"instance_assets/{name}"
+            else:
+                item["expandedImageURL"] = ""
         # Grid
         name = pathlib.Path(self.content["target_img_expanded_url"]).name
-        self.scraper.download_file(
+        if self.scraper.download_file(
             prepare_url(
                 self.content["target_img_expanded_url"], self.scraper.instance_url
             ),
             self.scraper.instance_assets_dir.joinpath(name),
-        )
-        self.content["target_img_expanded_url"] = (
-            get_back_jumps(5) + f"instance_assets/{name}"
-        )
+        ):
+            self.content["target_img_expanded_url"] = (
+                get_back_jumps(5) + f"instance_assets/{name}"
+            )
+        else:
+            self.content["target_img_expanded_url"] = ""
 
     def render(self):
         return jinja(None, "DragAndDropV2.html", False, dragdrop_content=self.content)


### PR DESCRIPTION
This fixes #105 by returning the download status (success/failure) from download_file() and using the result to decide whether to rewrite a link.

However, even after this, some weird mailto: links are still invalid and that's due to a bug with scraperlib. I've opened https://github.com/openzim/python_scraperlib/issues/46 for that

Also, there's a script which has a template and that's actually identified by zimcheck wrongly as an invalid link (and thus it's large number, as it's present in every HTML file with PHZH ZIMs). Have opened https://github.com/openzim/zim-tools/issues/149 for that.