### PR TITLE
Fix video template and display and cookie warning

### DIFF
--- a/openedx2zim/html_processor.py
+++ b/openedx2zim/html_processor.py
@@ -288,6 +288,7 @@ class HtmlProcessor:
                             subs=[],
                             autoplay=self.scraper.autoplay,
                             path_to_root=root_from_html,
+                            title="",
                         )
                         iframe.getparent().replace(iframe, lxml.html.fromstring(x))
                 elif ".pdf" in src:

--- a/openedx2zim/templates/assets/main.css
+++ b/openedx2zim/templates/assets/main.css
@@ -565,13 +565,8 @@ div.zim-course-wrapper section.zim-course-content .vert-mod .vert > .xblock-stud
     margin-bottom: 15px;
     padding: 0 0 15px;
 }
-.video {
-    background: #f0f3f5;
-    display: block;
-    margin: 0 -12px;
-    padding: 12px;
-    border-radius: 5px;
-    outline: none;
+.video-wrapper {
+    height: 270px;
 }
 .content-wrapper .course-license, .content-wrapper .xblock-license {
     text-align: right;

--- a/openedx2zim/templates/base.html
+++ b/openedx2zim/templates/base.html
@@ -18,6 +18,12 @@
     <script src="{{ rooturl }}assets/videojs-ogvjs.js"></script>
     {% block addhead %}{% endblock %}
     <script type="text/javascript" src="{{ rooturl }}assets/mooc.js"></script>
+    <style>
+      /* hide the cookie warning */
+      .cc-grower {
+        display: none;
+      }
+    </style>
   </head>
   <body class="{% block bodyclass %}{% endblock %}">
     <div class="zim-topmobilebar">

--- a/openedx2zim/templates/video.html
+++ b/openedx2zim/templates/video.html
@@ -1,13 +1,22 @@
-{% if self.no_video != False %}
-<video class="video video-js vjs-default-skin" 
-  controls preload="auto"
-  width="480px" height="270px"
-  data-setup='{"techOrder": ["html5", "ogvjs"], "ogvjs": {"base": "{{ path_to_root }}assets/ogvjs"}, "autoplay": {% if autoplay %}true{% else %}false{% endif %}, "preload": true, "controls": true, "controlBar": {"pictureInPictureToggle":false}}'>
-  <source src="{{ video_path }}" type="video/{{ format }}" />
-  {% for language in subs %}
-    <track kind="subtitles" src="{{ language["file"] }}" srclang="{{ language["code"] }}" label="{{ language["code"] }}" />
-  {% endfor %}
-</video>
-{% else %}
+<div class="xblock xblock-student_view xblock-student_view-video xmodule_display xmodule_VideoBlock xblock-initialized">
+  <h3 class="hd hd2">{{ title }}</h3>
+  {% if self.no_video != False %}
+  <div class="video is-initialized">
+      <div class="tc-wrapper">
+          <div class="video-wrapper" style="width: 100%;">
+              <video class="video-js vjs-default-skin vjs-fill" 
+                  controls preload="auto"
+                  data-setup='{"techOrder": ["html5", "ogvjs"], "ogvjs": {"base": "{{ path_to_root }}assets/ogvjs"}, "autoplay": {% if autoplay %}true{% else %}false{% endif %}, "preload": true, "controls": true, "controlBar": {"pictureInPictureToggle":false}}'>
+                  <source src="{{ video_path }}" type="video/{{ format }}" />
+                  {% for language in subs %}
+                  <track kind="subtitles" src="{{ language["file"] }}" srclang="{{ language["code"] }}" label="{{ language["code"] }}" />
+                  {% endfor %}
+              </video>
+          </div>
+      </div>
+  </div>
+  {% else %}
   <p> Sorry this video has not been downloaded </p>
-{% endif %}
+  {% endif %}
+</div>
+


### PR DESCRIPTION
This fixes #112 by making the template similar to the online structure used by openedx instances. Also removed unnecessary CSS that applied to videos.

Also fixes #113 by adding `display:none` to it's style

Some screenshots -
![Screenshot from 2020-08-18 00-48-16](https://user-images.githubusercontent.com/17774888/90435576-d2b1e900-e0ec-11ea-9179-e079bbd702f3.png)
![Screenshot from 2020-08-18 00-48-02](https://user-images.githubusercontent.com/17774888/90435826-3c31f780-e0ed-11ea-9ef3-ddac2ddf5d9e.png)


