### PR TITLE
Bump zimscraperlib to 1.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Jinja2==2.11.2
 mistune==2.0.0a4
 requests>=2.24,<3.0
 iso-639==0.4.5
-zimscraperlib>=1.2.1,<1.3
+zimscraperlib>=1.3.0,<1.4
 kiwixstorage>=0.3,<1.0
 pif==0.8.2
 xxhash==2.0.0


### PR DESCRIPTION
This bumps zimscraperlib to v1.3.0 to have support for the required fixes.