### PR TITLE
Fixes recursive paths in HTML processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 1.0.1.dev0
 
-- n/a
+- fixed recursive paths and URLs in html_processor.py
 
 # 1.0.0
 

--- a/openedx2zim/utils.py
+++ b/openedx2zim/utils.py
@@ -25,6 +25,9 @@ def prepare_url(url, netloc, path_on_remote=None):
     elif url.startswith("/"):
         url = f"{netloc}{url}"
     else:
+        # add a scheme first to prevent wrong URL parsing
+        if not url.startswith("http://") and not url.startswith("https://"):
+            url = f"http://{url}"
         parsed_url = urllib.parse.urlparse(url)
         if not parsed_url.netloc and path_on_remote:
             url = f"{netloc}{str(pathlib.Path(path_on_remote).joinpath(url))}"


### PR DESCRIPTION
This does the following -
- adds `get_path_and_netloc_to_send()` to calculate the netloc and the path on server to be passed in next recursion in html_processor.py properly
- add scheme in `prepare_url()` if not present already as its absence sometimes makes `urllib.parse.urlparse()` not correctly parse the URL resulting in messed up paths
- send correct path and netloc to `download_dependencies_from_css()` from `download_css_from_html()`
- process iframes only if content could be fetched from URL