### PR TITLE
Check if title is generated in video.html

### DIFF
--- a/openedx2zim/templates/video.html
+++ b/openedx2zim/templates/video.html
@@ -1,5 +1,5 @@
 <div class="xblock xblock-student_view xblock-student_view-video xmodule_display xmodule_VideoBlock xblock-initialized">
-  <h3 class="hd hd2">{{ title }}</h3>
+  <h3 class="hd hd-2">{% if title != "xblock" %}{{ title }}{% endif %}</h3>
   {% if self.no_video != False %}
   <div class="video is-initialized">
       <div class="tc-wrapper">


### PR DESCRIPTION
#151 was due to the fact that video xblocks do not have a title and we used `xblock` as title for such xblocks as we needed to maintain the directory structure to download assets (video in this case).

This changes the `video.html` template to check for the generated word `xblock` and add the title only if the title is not generated one. This maintains the same structure as the original one at PHZH.