### PR TITLE
Use dynamic versions for Open Sans font

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - added multithreading support
 - fixed missing videos due to youtube_dl error
 - added support for convertion in high quality
+- use dynamic versions for opensans font
 
 # 1.0.0
 

--- a/get_js_deps.sh
+++ b/get_js_deps.sh
@@ -26,6 +26,8 @@ curl -L -o opensans.zip http://google-webfonts-helper.herokuapp.com/api/fonts/op
 rm -rf $ASSETS_PATH/fonts/opensans
 mkdir -p $ASSETS_PATH/fonts/opensans
 unzip -o -d $ASSETS_PATH/fonts/opensans opensans.zip
+mv $ASSETS_PATH/fonts/opensans/*.woff $ASSETS_PATH/fonts/opensans/opensans.woff
+mv $ASSETS_PATH/fonts/opensans/*.woff2 $ASSETS_PATH/fonts/opensans/opensans.woff2
 rm -f opensans.zip
 
 echo "getting fontawesome"

--- a/openedx2zim/templates/assets/main.css
+++ b/openedx2zim/templates/assets/main.css
@@ -3,8 +3,8 @@
   font-style: normal;
   font-weight: 400;
   src: local('Open Sans Regular'), local('OpenSans-Regular'),
-     url('fonts/opensans/open-sans-v17-vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic-regular.woff2') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
-     url('fonts/opensans/open-sans-v17-vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic-regular.woff') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+     url('fonts/opensans/opensans.woff2') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
+     url('fonts/opensans/opensans.woff') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 
 * {


### PR DESCRIPTION
The opensans font version that we use has changed now, so its better to not depend on versions for it. The failure of https://farm.openzim.org/pipeline/5f6cd6fa9d9716ae942d85e0/debug was a result of this.

This allows renaming the file once downloaded to avoid dependence on version number.