### PR TITLE
Fix encoding to WebM with low quality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - added support for convertion in high quality
 - use dynamic versions for opensans font
 - fixed mobile navigation menu
+- fixed video encoding in low quality in WebM
 
 # 1.0.0
 

--- a/openedx2zim/scraper.py
+++ b/openedx2zim/scraper.py
@@ -621,6 +621,8 @@ class Openedx2Zim:
             target_dir=fpath.parent,
             filepath=pathlib.Path(f"{output_file_name}.%(ext)s"),
             format=f"best[ext={self.video_format}]/best",
+            writethumbnail=False,
+            write_all_thumbnails=False,
         )
         try:
             self.yt_downloader.download(url, options)
@@ -639,13 +641,13 @@ class Openedx2Zim:
             preset = VideoWebmLow() if self.video_format == "webm" else VideoMp4Low()
         elif src.suffix[1:] != self.video_format:
             preset = VideoWebmHigh() if self.video_format == "webm" else VideoMp4High()
-            return reencode(
-                src,
-                dst,
-                preset.to_ffmpeg_args(),
-                delete_src=True,
-                failsafe=False,
-            )
+        return reencode(
+            src,
+            dst,
+            preset.to_ffmpeg_args(),
+            delete_src=True,
+            failsafe=False,
+        )
 
     def optimize_image(self, src, dst):
         optimized = False


### PR DESCRIPTION
The missing videos were due to two reasons - 
1. When passing low quality, conversion didn't take place (the conversion code was in the elif block, which was incorrect)
2. The thumbnail was actually being passed for conversion instead of the video file.

This fixes #145 by disabling thumbnail download (we didn't use them anyway), and by moving the conversion code to the right place.