### PR TITLE
Remove space on top

### DIFF
--- a/openedx2zim/templates/vertical.html
+++ b/openedx2zim/templates/vertical.html
@@ -77,7 +77,7 @@ vertical
             <div id="seq_content">
             <div class="xblock xblock-student_view xblock-student_view-vertical xblock-initialized">
               <h2 class="hd hd-2 unit-title"> {{ vertical.xblock_json["display_name"] }} </h2>
-              <div class="vert-mod">
+              <div class="vert-mod" style="padding-top: 0;">
               {% for elem in vertical_content %}
               {{ elem }}
               {% endfor %}


### PR DESCRIPTION
Fixes #161 by removing the unnecessary padding on the top. Having that class is important to fetching the CSS and JS from the instances. However, since there is a navigation on the top, the instance CSS also has this padding that gets applied. Set it to 0 in the element style.