### PR TITLE
Dynamically add language code to ZIM metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - fixed mobile navigation menu
 - fixed video encoding in low quality in WebM
 - added support for internationalization
+- have proper language in ZIM metadata
 
 # 1.0.0
 

--- a/openedx2zim/scraper.py
+++ b/openedx2zim/scraper.py
@@ -872,7 +872,7 @@ class Openedx2Zim:
                 favicon="favicon.png",
                 title=zim_info["title"],
                 description=zim_info["description"],
-                language="eng",
+                language=get_language_details(self.instance_lang)["iso-639-3"],
                 creator=zim_info["creator"],
                 publisher=self.publisher,
                 tags=self.tags + ["_category:other", "openedx"],


### PR DESCRIPTION
Adds the 3-letter language code to ZIM metadata dynamically instead of the hardcoded `eng` value.