### PR TITLE
Move inline JS to regular file + other small fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Unreleased
 
-- scraper will fail when there are too many erros while retrieving xblocks
+- scraper will fail when there are too many errors while retrieving xblocks
+- add a Creative Commons sample EDX course
+- move all inline Javascript to standalone files to comply with some CSP
+- no more retry for login + HTTP errors
+- pin markupsafe until we upgrade Jinja2
+- fix issue with video that do not need to be re-encoded and were marked as missing
 
 # 1.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
 # Unreleased
 
 - scraper will fail when there are too many errors while retrieving xblocks
-- add a Creative Commons sample EDX course
 - move all inline Javascript to standalone files to comply with some CSP
 - no more retry for login + HTTP errors
 - display HTTP error responses or save them in a temporary file for analysis
 - save API response for course xblocks in temporary file for debugging
 - pin markupsafe until we upgrade Jinja2
 - fix issue with video that do not need to be re-encoded and were marked as missing
+- README.md: replace course in sample command by one under a Creative Commons license
 
 # 1.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - add a Creative Commons sample EDX course
 - move all inline Javascript to standalone files to comply with some CSP
 - no more retry for login + HTTP errors
+- display HTTP error responses or save them in a temporary file for analysis
 - pin markupsafe until we upgrade Jinja2
 - fix issue with video that do not need to be re-encoded and were marked as missing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - move all inline Javascript to standalone files to comply with some CSP
 - no more retry for login + HTTP errors
 - display HTTP error responses or save them in a temporary file for analysis
+- save API response for course xblocks in temporary file for debugging
 - pin markupsafe until we upgrade Jinja2
 - fix issue with video that do not need to be re-encoded and were marked as missing
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ openedx2zim --help
 
 Example usage
 ```bash
-openedx2zim --course-url="https://courses.edx.org/courses/course-v1:edX+edx201+1T2020/course/" --publisher="edx201" --email="example@example.com" --name="sample" --tmp-dir="output" --output="output" --debug  --keep --format="mp4"
+openedx2zim --course-url="https://openlearninglibrary.mit.edu/courses/course-v1:OCW+6.042J+2T2019/course/" --publisher="Massachusetts Institute of Technology" --email="example@example.com" --name="sample" --tmp-dir="output" --output="output" --debug  --keep --format="mp4"
 ```
 
 This project can also be run with docker. Use the provided [Dockerfile](Dockerfile) to run it with docker. See steps [here](https://docs.docker.com/get-started/part2/).

--- a/get_js_deps.sh
+++ b/get_js_deps.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 ###
 # download JS dependencies and place them in our templates/assets folder
 # then launch our ogv.js script to fix dynamic loading links
@@ -22,7 +24,7 @@ ASSETS_PATH="${SCRIPT_PATH}/openedx2zim/templates/assets"
 echo "About to download JS assets to ${ASSETS_PATH}"
 
 echo "getting open sans font"
-curl -L -o opensans.zip http://google-webfonts-helper.herokuapp.com/api/fonts/open-sans?download=zip\&subsets=vietnamese,latin-ext,latin,greek-ext,greek,cyrillic-ext,cyrillic\&variants=regular\&formats=woff,woff2
+curl -L -o opensans.zip https://gwfh.mranftl.com/api/fonts/open-sans?download=zip\&subsets=vietnamese,latin-ext,latin,greek-ext,greek,cyrillic-ext,cyrillic\&variants=regular\&formats=woff,woff2
 rm -rf $ASSETS_PATH/fonts/opensans
 mkdir -p $ASSETS_PATH/fonts/opensans
 unzip -o -d $ASSETS_PATH/fonts/opensans opensans.zip

--- a/openedx2zim/html_processor.py
+++ b/openedx2zim/html_processor.py
@@ -228,6 +228,7 @@ class HtmlProcessor:
                                     path_from_html, root_from_html
                                 ),
                                 audio_format=file_format,
+                                mooc=self.scraper,
                             )
                         filename = html_fpath.name
                     anchor.attrib["href"] = (
@@ -374,6 +375,7 @@ class HtmlProcessor:
                             autoplay=self.scraper.autoplay,
                             path_to_root=root_from_html,
                             title="",
+                            mooc=self.scraper,
                         )
                         iframe.getparent().replace(iframe, lxml.html.fromstring(x))
                 elif ".pdf" in src:

--- a/openedx2zim/instance_connection.py
+++ b/openedx2zim/instance_connection.py
@@ -3,7 +3,6 @@ import getpass
 import http
 import json
 import sys
-import tempfile
 import urllib
 
 from .constants import getLogger, LANGUAGE_COOKIES, OPENEDX_LANG_MAP
@@ -34,12 +33,7 @@ class InstanceConnection:
                 logger.debug(f"HTTP Error (won't retry this kind of error) while opening {url}: {exc}")
                 if self.debug:
                     responseData = exc.read().decode("utf8", 'ignore')
-                    if len(responseData) > 256:
-                        with tempfile.NamedTemporaryFile(dir=self.build_dir.joinpath("logs"), suffix=".raw", mode="wt", delete=False) as fp:
-                            fp.write(responseData)
-                            logger.debug(f"Error response saved in {fp.name}")
-                    else:
-                        logger.debug(responseData)
+                    print(responseData, file=sys.stderr)
                 raise exc
             except urllib.error.URLError as exc:
                 if attempt < max_attempts - 1:

--- a/openedx2zim/instance_connection.py
+++ b/openedx2zim/instance_connection.py
@@ -19,6 +19,14 @@ def get_response(url, post_data, headers, max_attempts=5):
     for attempt in range(max_attempts):
         try:
             return urllib.request.urlopen(req).read().decode("utf-8")
+        except urllib.error.HTTPError as exc:
+            logger.debug(
+                f"HTTP Error opening {url}: {exc}\n"
+                "Won't retry this kind of error.\n"
+                "Error response body below:")
+            responseData = exc.read().decode("utf8", 'ignore')
+            logger.debug(responseData)
+            raise exc
         except urllib.error.URLError as exc:
             if attempt < max_attempts - 1:
                 logger.debug(f"Error opening {url}: {exc}\nRetrying ...")
@@ -27,9 +35,6 @@ def get_response(url, post_data, headers, max_attempts=5):
                     f"Error opening {url}: {exc},"
                     f" max attempts ({max_attempts}) exceeded"
                 )
-                responseData = exc.read().decode("utf8", 'ignore')
-                logger.debug(responseData)
-                raise exc
         except Exception as exc:
             logger.debug(f"Fatal error opening {url}: {exc}")
             raise exc

--- a/openedx2zim/scraper.py
+++ b/openedx2zim/scraper.py
@@ -294,7 +294,7 @@ class Openedx2Zim:
                     logger.error(
                         f"Unsupported xblock: {current_xblock['type']} URL: {current_xblock['student_view_url']}"
                         f"  You can open an issue at https://github.com/openzim/openedx/issues with this log and MOOC URL"
-                        f"  You can ignore this message by passing --ignore-missing-xblocks in atguments"
+                        f"  You can ignore this message by passing --ignore-missing-xblocks in arguments"
                     )
                     sys.exit(1)
                 else:

--- a/openedx2zim/scraper.py
+++ b/openedx2zim/scraper.py
@@ -144,6 +144,7 @@ class Openedx2Zim:
         if tmp_dir:
             pathlib.Path(tmp_dir).mkdir(parents=True, exist_ok=True)
         self.build_dir = pathlib.Path(tempfile.mkdtemp(dir=tmp_dir))
+        self.build_dir.joinpath("logs").mkdir(parents=True, exist_ok=True)
 
         # scraper options
         self.course_url = course_url
@@ -322,6 +323,7 @@ class Openedx2Zim:
             current_id=self.root_xblock_id,
             root_url="../",
         )
+        logger.debug(f"{len(self.xblock_extractor_objects)} xblocks will be extracted")
 
     def get_book_list(self, book, output_path):
         pdf = book.find_all("a")
@@ -869,6 +871,8 @@ class Openedx2Zim:
             self.password,
             self.instance_config,
             self.instance_lang,
+            build_dir=self.build_dir,
+            debug=self.debug,
         )
         self.instance_connection.establish_connection()
         jinja_init()

--- a/openedx2zim/scraper.py
+++ b/openedx2zim/scraper.py
@@ -14,6 +14,7 @@ import sys
 import tempfile
 import urllib
 import uuid
+import json
 
 from bs4 import BeautifulSoup
 from kiwixstorage import KiwixStorage
@@ -257,6 +258,10 @@ class Openedx2Zim:
             + "&depth=all&requested_fields=graded,format,student_view_multi_device&student_view_data=video,discussion&block_counts=video,discussion,problem&nav_depth=3"
         )
         self.course_xblocks = xblocks_data["blocks"]
+        if self.debug:
+            with tempfile.NamedTemporaryFile(dir=self.build_dir.joinpath("logs"), suffix=".json", mode="wt", delete=False) as fp:
+                json.dump(self.course_xblocks, fp, indent=4)
+                logger.debug(f"Saved API response while fetching list of course blocks in {fp.name}")
         self.root_xblock_id = xblocks_data["root"]
 
     def parse_course_xblocks(self):

--- a/openedx2zim/scraper.py
+++ b/openedx2zim/scraper.py
@@ -681,6 +681,8 @@ class Openedx2Zim:
             preset = VideoWebmLow() if self.video_format == "webm" else VideoMp4Low()
         elif src.suffix[1:] != self.video_format:
             preset = VideoWebmHigh() if self.video_format == "webm" else VideoMp4High()
+        else:
+            return False  # no need to convert, original file must be kept as-is
         return reencode(
             src,
             dst,

--- a/openedx2zim/templates/assets/base.js
+++ b/openedx2zim/templates/assets/base.js
@@ -1,0 +1,24 @@
+window.MathJax = {
+    tex: {
+        inlineMath: [
+            ["\\(", "\\)"],
+            ['[mathjaxinline]', '[/mathjaxinline]']
+        ],
+        displayMath: [
+            ["\\[", "\\]"],
+            ['[mathjax]', '[/mathjax]']
+        ],
+        autoload: {
+            color: [],
+            colorV2: ['color']
+        },
+        packages: { '[+]': ['noerrors'] }
+    },
+    options: {
+        ignoreHtmlClass: 'tex2jax_ignore',
+        processHtmlClass: 'tex2jax_process'
+    },
+    loader: {
+        load: ['input/asciimath', '[tex]/noerrors']
+    }
+};

--- a/openedx2zim/templates/assets/booknav.js
+++ b/openedx2zim/templates/assets/booknav.js
@@ -1,0 +1,15 @@
+function booknav_change() {
+    if (window.matchMedia('(max-width: 640px)').matches) { // On mobile, we launch download of pdf
+        return true;
+    } else {
+        document.getElementById("viewer-frame").src = this.href;
+        return false;
+    }
+}
+
+$(window).on('load', function () {
+    const chapters = document.getElementsByClassName("zim-chapter");
+    for (var i = 0; i < chapters.length; ++i) {
+        chapters[i].addEventListener("click", booknav_change);
+    }
+});

--- a/openedx2zim/templates/assets/freetextresponse.js
+++ b/openedx2zim/templates/assets/freetextresponse.js
@@ -1,0 +1,34 @@
+/*
+function check_freetext(text_id){
+  alert("Sorry, we cannot check free text offline"); 
+}
+*/
+
+function save_freetext() {
+    var text_id = this.dataset.textid
+    document.cookie = courseNameSlug + "-" + text_id + "=" + document.getElementById(text_id).value;
+}
+
+function load_freetext(text_id) {
+    var name = courseNameSlug + "-" + text_id + "=";
+    var cookie_split = document.cookie.split(';');
+    for (var i = 0; i < cookie_split.length; i++) {
+        var c = cookie_split[i];
+        while (c.charAt(0) == ' ') c = c.substring(1, c.length);
+        if (c.indexOf(name) == 0) { document.getElementById(text_id).value = c.substring(name.length, c.length); break; }
+    }
+}
+
+$(window).on('load', function () {
+    const courseNameSlug = document.querySelector('meta[name="course_name_slug"]').content
+
+    const studentAnswer = document.getElementsByClassName("student_answer");
+    for (var i = 0; i < studentAnswer.length; ++i) {
+        load_freetext(studentAnswer[i].id)
+    }
+
+    const saveBtns = document.getElementsByClassName("zim-save_freetext");
+    for (var i = 0; i < saveBtns.length; ++i) {
+        saveBtns[i].addEventListener("click", save_freetext);
+    }
+});

--- a/openedx2zim/templates/assets/freetextresponse.js
+++ b/openedx2zim/templates/assets/freetextresponse.js
@@ -1,9 +1,3 @@
-/*
-function check_freetext(text_id){
-  alert("Sorry, we cannot check free text offline"); 
-}
-*/
-
 function save_freetext() {
     var text_id = this.dataset.textid
     document.cookie = courseNameSlug + "-" + text_id + "=" + document.getElementById(text_id).value;

--- a/openedx2zim/templates/assets/mooc.js
+++ b/openedx2zim/templates/assets/mooc.js
@@ -42,8 +42,8 @@ function show_forum_menu(){
 }
 
 
-function show_forum(threads_id){
-  var e = document.getElementById(threads_id);
+function show_forum(){
+  var e = document.getElementById(this.dataset.threadsid);
   if(e.style.display == 'none') {
     e.style.display = 'block';
   }else{
@@ -51,14 +51,41 @@ function show_forum(threads_id){
   }
 }
 
-function toggle_visibility_submenu(elem){
-    var e = elem.nextSibling.nextSibling;
+function toggle_visibility_submenu(){
+    var e = this.nextSibling.nextSibling;
     if(e.style.display == 'block' || e.style.display == '') {
         e.style.display = 'none';
     }else{
         e.style.display = 'block';
     }
-    elem.children[0].children[0].classList.toggle("fa-caret-down");
-    elem.children[0].children[0].classList.toggle("fa-caret-right");
+    this.children[0].children[0].classList.toggle("fa-caret-down");
+    this.children[0].children[0].classList.toggle("fa-caret-right");
 }
 
+
+$(window).on('load', function () {
+  const chapters = document.getElementsByClassName("zim-button-chapter");
+  for (var i = 0; i < chapters.length; ++i) {
+    chapters[i].addEventListener("click", toggle_visibility_submenu);
+  }
+  
+  const mobileMenu = document.getElementById("zim-show_pagemobilemenu")
+  if (mobileMenu) {
+    mobileMenu.addEventListener("click", show_pagemobilemenu);
+  }
+  
+  const sidemenus = document.getElementsByClassName("zim-side_menu");
+  for (var i = 0; i < sidemenus.length; ++i) {
+    sidemenus[i].addEventListener("click", show_sidemenu);
+  }
+  
+  const forummenus = document.getElementsByClassName("zim-forum_menu");
+  for (var i = 0; i < forummenus.length; ++i) {
+    forummenus[i].addEventListener("click", show_forum_menu);
+  }
+  
+  const forumLinks =  document.getElementsByClassName("zim-forum_link");
+  for (var i = 0; i < forumLinks.length; ++i) {
+    forumLinks[i].addEventListener("click", show_forum);
+  }
+});

--- a/openedx2zim/templates/assets/vertical.js
+++ b/openedx2zim/templates/assets/vertical.js
@@ -1,0 +1,9 @@
+
+function trigger_seq_content_change_behaviour() {
+    $('#seq_content').append("<div id='dummy_div'></div>");
+    $('#dummy_div').remove();
+}
+
+$(window).on('load', function () {
+    trigger_seq_content_change_behaviour();
+});

--- a/openedx2zim/templates/assets/xblocks.js
+++ b/openedx2zim/templates/assets/xblocks.js
@@ -1,6 +1,7 @@
 problem_answers = {};
 
-function problem_check_answers(problem_id) {
+function problem_check_answers() {
+    var e = document.getElementById(this.dataset.problemid);
     var problem_node = document.getElementById(problem_id)
     var inputs = problem_node.getElementsByTagName('input');
     var answer_id = "";
@@ -20,3 +21,10 @@ function problem_check_answers(problem_id) {
         trigger_seq_content_change_behaviour();
     }
 }
+
+$(window).on('load', function () {
+    const probemBtns = document.getElementsByClassName("zim-problem_btn");
+    for (var i = 0; i < probemBtns.length; ++i) {
+        probemBtns[i].addEventListener("click", problem_check_answers);
+    }
+});

--- a/openedx2zim/templates/base.html
+++ b/openedx2zim/templates/base.html
@@ -6,6 +6,7 @@
     <meta name="generator" content="https://github.com/openzim/openedx/"/>
     <meta name="author" content="kiwix team"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <meta name="course_name_slug" content="{{ mooc.course_name_slug }}"/>
     <link id="favicon" rel="shortcut icon" href="{{ rooturl }}favicon.png" type="image/png">
     {% if rtl %}
     <link href="{{ rooturl }}assets/main_rtl.css" rel="stylesheet" type="text/css" />
@@ -32,11 +33,11 @@
   <body class="{% if rtl %}rtl{% else %}ltr{% endif %} {%block bodyclass %}{% endblock %}">
     <div class="zim-topmobilebar">
       {% if side_menu or forum_menu %}
-        <a onclick="{% if side_menu %}show_sidemenu(){% else %}show_forum_menu(){% endif %}" id="zim-show_sidemenu">
+        <a class="{% if side_menu %}zim-side_menu{% else %}zim-forum_menu{% endif %}" id="zim-show_sidemenu">
           <i class="fa fa-bars"></i>
         </a>
       {% endif %}
-      <a onclick="show_pagemobilemenu()" id="zim-show_pagemobilemenu">
+      <a id="zim-show_pagemobilemenu">
         <i class="fa fa-angle-down"></i>
       </a>
     </div>
@@ -59,32 +60,7 @@
    </div>
     </div>
     {% block body_end %}{% endblock %}
-    <script>
-      window.MathJax = {
-        tex: {
-          inlineMath: [
-          ["\\(","\\)"],
-          ['[mathjaxinline]','[/mathjaxinline]']
-              ],
-          displayMath: [
-          ["\\[","\\]"],
-          ['[mathjax]','[/mathjax]']
-              ],
-          autoload: {
-            color: [],
-            colorV2: ['color']
-          },
-          packages: {'[+]': ['noerrors']}
-        },
-        options: {
-          ignoreHtmlClass: 'tex2jax_ignore',
-          processHtmlClass: 'tex2jax_process'
-        },
-        loader: {
-          load: ['input/asciimath', '[tex]/noerrors']
-        }
-      };
-      </script>
+    <script type="text/javascript" src="{{ rooturl }}assets/base.js"></script>
     <script type="text/javascript" src="{{ rooturl }}assets/mathjax/tex-mml-svg.js"></script>
   </body>
 </html>

--- a/openedx2zim/templates/booknav.html
+++ b/openedx2zim/templates/booknav.html
@@ -12,7 +12,7 @@
 	    <ul id="zim-booknav">
 	    {% for book in book_list %}
 		  <li>
-		    <a class="zim-chapter" rel="{{ book["url"] }}" href="{{ rooturl }}{{ dir_path }}/{{ book["url"] }}" onclick="return booknav_change(this)"> {{ book["name"] }}</a>
+		    <a class="zim-chapter" rel="{{ book["url"] }}" href="{{ rooturl }}{{ dir_path }}/{{ book["url"] }}"> {{ book["name"] }}</a>
 		  </li>
 	    {% endfor %}
 	    </ul>
@@ -31,15 +31,6 @@
 </div>
 </main>
 </div>
-<script>
-function booknav_change(e){
-	if (window.matchMedia('(max-width: 640px)').matches) { // On mobile, we launch download of pdf
-		return true;
-        }else{
-		document.getElementById("viewer-frame").src = e.href;
-		return false;
-	}
-}
-</script>
+<script type="text/javascript" src="{{ rooturl }}assets/booknav.js"></script>
 
 {% endblock %}

--- a/openedx2zim/templates/forum.html
+++ b/openedx2zim/templates/forum.html
@@ -15,7 +15,7 @@
           {% for cat in category %}
               <li class="forum-nav-browse-menu-item" data-discussion-id='{{ cat }}'>
 		{% if not "catego_with_sub_catego" in category[cat] %}
-                <a onclick="show_forum('{{ cat }}')" > <!--href="{{ cat }}/index.html"-->
+                <a class="zim-forum_link" data-threadsid="{{ cat }}" > <!--href="{{ cat }}/index.html"-->
 		{% endif %}
                   <span class="forum-nav-browse-title">
                     {{ category[cat]["title"] }}

--- a/openedx2zim/templates/freetextresponse.html
+++ b/openedx2zim/templates/freetextresponse.html
@@ -1,27 +1,2 @@
 {{ freetextresponse_html }}
-<script>
-
-/*
-function check_freetext(text_id){
-  alert("Sorry, we cannot check free text offline"); 
-}
-*/
-
-function save_freetext(text_id){
-  document.cookie = "{{ mooc.course_name_slug }}-" + text_id + "=" + document.getElementById(text_id).value;
-}
-
-function load_freetext(text_id){
-  var name = "{{ mooc.course_name_slug }}-" + text_id + "=";
-  var cookie_split = document.cookie.split(';');
-  for(var i=0; i < cookie_split.length;i++){
-    var c = cookie_split[i];
-    while (c.charAt(0)==' ') c = c.substring(1,c.length);
-    if(c.indexOf(name) == 0){ document.getElementById(text_id).value = c.substring(name.length,c.length); break; }
-  }
-}
-
-load_freetext("{{ freetextresponse_id  }}");
-
-</script>
-
+<script type="text/javascript" src="{{ rooturl }}assets/freetextresponse.js"></script>

--- a/openedx2zim/templates/problem.html
+++ b/openedx2zim/templates/problem.html
@@ -7,7 +7,7 @@
             <div class="action">
                 <script type="text/javascript" src="{{ path_to_root }}instance_assets/{{ problem_id }}_answers.js"></script>
                 <div class="submit-attempt-container">
-                <button type="button" class="submit btn-brand" onclick="problem_check_answers('{{ problem_id }}')" >          <span class="submit-label">Submit</span>      </button>
+                <button type="button" class="submit btn-brand zim-problem_btn" data-problemid="{{ problem_id }}">          <span class="submit-label">Submit</span>      </button>
                 </div>
             </div>
             {% endif %}

--- a/openedx2zim/templates/side_menu.html
+++ b/openedx2zim/templates/side_menu.html
@@ -5,7 +5,7 @@
       {% if chapter_.descendants|length > 0 %}
 <!--        <li>-->
           {% if chapter and chapter_.id == chapter.id  or all_side_menu_open %}
-            <a class="zim-button-chapter chapter zim-active" role="button" aria-expanded="true" onclick='toggle_visibility_submenu(this)'>
+            <a class="zim-button-chapter chapter zim-active" role="button" aria-expanded="true">
               <span class="zim-group-heading zim-active" aria-label="{{ chapter_.display_name }}">
                 <span class="icon fa fa-caret-down" aria-hidden="true"></span>
                 {{ chapter_.display_name }}
@@ -13,7 +13,7 @@
             </a>
             <div class="zim-chapter-content-container" {#" is-open" tabindex="-1" #} role="group" aria-label="{{ chapter_.display_name }} submenu" style="display:block;">
             {% else %}
-            <a class="zim-button-chapter chapter" role="button" aria-expanded="false" onclick='toggle_visibility_submenu(this)'>
+            <a class="zim-button-chapter chapter" role="button" aria-expanded="false">
               <span class="zim-group-heading" aria-label="{{ chapter_.display_name }}">
                 <span class="icon fa fa-caret-right" aria-hidden="true"></span>
                 {{ chapter_.display_name }}

--- a/openedx2zim/templates/vertical.html
+++ b/openedx2zim/templates/vertical.html
@@ -128,14 +128,5 @@ vertical
 <!-- workaround to simulate sequential content change behaviour as some custom JS may depend on this
      we do this as our seq_content is static (as we have HTML at vertical level) but seq_content on instances 
      is not static (as they have HTML at sequential level) -->
-<script type="text/javascript">
-function trigger_seq_content_change_behaviour(){
-  $('#seq_content').append("<div id='dummy_div'></div>");
-  $('#dummy_div').remove();
-}
-
-$(window).load(function(){
-  trigger_seq_content_change_behaviour();
-});
-</script>
+<script type="text/javascript" src="{{ rooturl }}assets/vertical.js"></script>
 {% endblock %}

--- a/openedx2zim/xblocks_extractor/discussion.py
+++ b/openedx2zim/xblocks_extractor/discussion.py
@@ -110,6 +110,7 @@ class Discussion(BaseXblock):
                 pre_discussion_content=self.pre_discussion_content,
                 post_discussion_content=self.post_discussion_content,
                 discussion_header=self.discussion_header,
+                mooc=self.scraper,
             )
         if not self.scraper.forum:
             # render nothing in no forum mode

--- a/openedx2zim/xblocks_extractor/drag_and_drop_v2.py
+++ b/openedx2zim/xblocks_extractor/drag_and_drop_v2.py
@@ -56,4 +56,10 @@ class DragAndDropV2(
             self.content["target_img_expanded_url"] = ""
 
     def render(self):
-        return jinja(None, "DragAndDropV2.html", False, dragdrop_content=self.content)
+        return jinja(
+            None,
+            "DragAndDropV2.html",
+            False,
+            dragdrop_content=self.content,
+            mooc=self.scraper,
+        )

--- a/openedx2zim/xblocks_extractor/free_text_response.py
+++ b/openedx2zim/xblocks_extractor/free_text_response.py
@@ -31,8 +31,8 @@ class FreeTextResponse(BaseXblock):
         # check = soup.find("button", attrs={"class": "check"}).decompose()
         save = soup.find("button", attrs={"class": "save"})
         text_area["id"] = self.xblock_id
-        # check["onclick"] = 'check_freetext("{}")'.format(self.id)
-        save["onclick"] = 'save_freetext("{}")'.format(self.xblock_id)
+        save["data-textid"] = self.xblock_id
+        save['class'].append('zim-save_freetext')
         html_no_answers = '<div class="noanswers"><p data-l10n-id="no_answers_for_freetext" >  <b> Warning : </b> There is not correction for Freetext block. </p> </div>'
         self.html = (
             html_no_answers
@@ -50,6 +50,5 @@ class FreeTextResponse(BaseXblock):
             "freetextresponse.html",
             False,
             freetextresponse_html=self.html,
-            freetextresponse_id=self.xblock_id,
             mooc=self.scraper,
         )

--- a/openedx2zim/xblocks_extractor/libcast.py
+++ b/openedx2zim/xblocks_extractor/libcast.py
@@ -62,4 +62,5 @@ class Libcast(BaseXblock):
             subs=self.subs,
             autoplay=self.scraper.autoplay,
             path_to_root=get_back_jumps(5),
+            mooc=self.scraper,
         )

--- a/openedx2zim/xblocks_extractor/problem.py
+++ b/openedx2zim/xblocks_extractor/problem.py
@@ -276,4 +276,5 @@ class Problem(BaseXblock):
             html_content=self.html_content,
             path_to_root=get_back_jumps(5),
             answers_available=self.answers_available,
+            mooc=self.scraper,
         )

--- a/openedx2zim/xblocks_extractor/video.py
+++ b/openedx2zim/xblocks_extractor/video.py
@@ -165,4 +165,5 @@ class Video(BaseXblock):
             subs=self.subs,
             autoplay=self.scraper.autoplay,
             path_to_root=get_back_jumps(5),
+            mooc=self.scraper,
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,7 @@ pif>=0.8.2,<0.9
 xxhash>=2.0.0,<2.1
 # youtube-dl should be updated as frequently as possible
 youtube_dl
+# Jinja2 2.11 depends on soft_unicode which has been remove from markupsafe after 2.0.1
+# so we pin the version to 2.0.1 ; this HAS to be removed once Jinja2 is update to a more
+# recent version
+markupsafe==2.0.1


### PR DESCRIPTION
## Rationale

- Fix #168 + other small issues
- Enhance logging around HTTP errors 
- Stop retrying HTTP errors since in most cases, the error is not transient + might lead to user ban
- Replace the example course in README.md with another one in CC-BY-SA-NC (in order to avoid issues like what happened to youtube-dl)

## Changes
- add a Creative Commons sample EDX course
- move all inline Javascript to standalone files to comply with some CSP
- no more retry for login + HTTP errors
- display HTTP error responses or save them in a temporary file for analysis
- pin markupsafe until we upgrade Jinja2
- fix issue with video that do not need to be re-encoded and were marked as missing