### PR TITLE
Fail scrapper when there are too many errors while retrieving xblocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- scraper will fail when there are too many erros while retrieving xblocks
+
 # 1.0.1
 
 - fixed recursive paths and URLs in html_processor.py

--- a/openedx2zim/annex.py
+++ b/openedx2zim/annex.py
@@ -355,14 +355,14 @@ class MoocWiki:
         while page_to_visit:
             url = page_to_visit.pop()
             self.add_to_wiki_data(url)
-            content = self.scraper.instance_connection.get_page(url)
-            # Parse content page
-            if content:
+            try:
+                content = self.scraper.instance_connection.get_page(url)
+                # Parse content page
                 soup = BeautifulSoup(content, "lxml")
                 text = soup.find("div", attrs={"class": "wiki-article"})
                 if text:  # If it's a page (and not a list of page)
                     self.update_wiki_page(soup, text, url, page_to_visit)
-            else:
+            except Exception:
                 self.wiki_data[url][
                     "text"
                 ] = """<div><h1 class="page-header">Permission Denied</h1><p class="alert denied">Sorry, you don't have permission to view this page.</p></div>"""

--- a/openedx2zim/entrypoint.py
+++ b/openedx2zim/entrypoint.py
@@ -203,6 +203,20 @@ def main():
     )
 
     parser.add_argument(
+        "--watcher-min-dl-count",
+        help="Minimum number of resources to have downloaded before considering to stop on errors",
+        type=int,
+        default=50,
+    )
+
+    parser.add_argument(
+        "--watcher-min-ratio",
+        help="Minimum ratio of resources processed successfully. If ratio is below this threshold, the scrapper will stop.",
+        type=float,
+        default=0.9,
+    )
+
+    parser.add_argument(
         "--version",
         help="Display scraper version and exit",
         action="version",

--- a/openedx2zim/entrypoint.py
+++ b/openedx2zim/entrypoint.py
@@ -204,7 +204,7 @@ def main():
 
     parser.add_argument(
         "--watcher-min-dl-count",
-        help="Minimum number of resources to have downloaded before considering to stop on errors",
+        help="[dev] Minimum number of resources to have downloaded before considering to stop on errors",
         type=int,
         default=50,
     )

--- a/openedx2zim/html_processor.py
+++ b/openedx2zim/html_processor.py
@@ -392,8 +392,9 @@ class HtmlProcessor:
                 else:
                     # handle iframe recursively
                     iframe_url = prepare_url(src, netloc)
-                    src_content = self.scraper.instance_connection.get_page(iframe_url)
-                    if not src_content:
+                    try:
+                        src_content = self.scraper.instance_connection.get_page(iframe_url)
+                    except Exception:
                         continue
                     path_recursive, netloc_recursive = self.get_path_and_netloc_to_send(
                         netloc, path_on_server, iframe_url

--- a/openedx2zim/instance_connection.py
+++ b/openedx2zim/instance_connection.py
@@ -10,6 +10,10 @@ from .constants import getLogger, LANGUAGE_COOKIES, OPENEDX_LANG_MAP
 logger = getLogger()
 
 
+class GetResponseFailed(Exception):
+    pass
+
+
 def get_response(url, post_data, headers, max_attempts=5):
     req = urllib.request.Request(url, post_data, headers)
     for attempt in range(max_attempts):
@@ -21,7 +25,7 @@ def get_response(url, post_data, headers, max_attempts=5):
             else:
                 logger.debug(f"Error opening {url}: {exc}")
     logger.error(f"Max attempts exceeded for {url}")
-    return {}
+    raise GetResponseFailed()
 
 
 class InstanceConnection:

--- a/openedx2zim/scraper.py
+++ b/openedx2zim/scraper.py
@@ -338,8 +338,9 @@ class Openedx2Zim:
     def annex_extra_page(self, tab_href, tab_org_path):
         output_path = self.build_dir.joinpath(tab_org_path)
         output_path.mkdir(parents=True, exist_ok=True)
-        page_content = self.instance_connection.get_page(self.instance_url + tab_href)
-        if not page_content:
+        try:
+            page_content = self.instance_connection.get_page(self.instance_url + tab_href)
+        except Exception:
             logger.error(f"Failed to get page content for tab {tab_org_path}")
             raise SystemExit(1)
         soup_page = BeautifulSoup(page_content, "lxml")
@@ -412,8 +413,9 @@ class Openedx2Zim:
 
     def get_course_tabs(self):
         logger.info("Getting course tabs ...")
-        content = self.instance_connection.get_page(self.course_url)
-        if not content:
+        try:
+            content = self.instance_connection.get_page(self.course_url)
+        except Exception:
             logger.error("Failed to get course tabs")
             raise SystemExit(1)
         soup = BeautifulSoup(content, "lxml")
@@ -517,8 +519,9 @@ class Openedx2Zim:
 
         # get the course url and generate homepage
         logger.info("Getting homepage ...")
-        content = self.instance_connection.get_page(self.course_url)
-        if not content:
+        try:
+            content = self.instance_connection.get_page(self.course_url)
+        except Exception:
             logger.error("Error while getting homepage")
             raise SystemExit(1)
         self.build_dir.joinpath("home").mkdir(parents=True, exist_ok=True)

--- a/openedx2zim/utils.py
+++ b/openedx2zim/utils.py
@@ -86,8 +86,9 @@ def download_and_convert_subtitles(output_path, subtitles, instance_connection):
         subtitle_file = pathlib.Path(output_path).joinpath(f"{lang}.vtt")
         if not subtitle_file.exists():
             try:
-                raw_subtitle = instance_connection.get_page(subtitles[lang])
-                if not raw_subtitle:
+                try:
+                    raw_subtitle = instance_connection.get_page(subtitles[lang])
+                except Exception:
                     logger.error(f"Subtitle fetch failed from {subtitles[lang]}")
                     continue
                 subtitle = html.unescape(

--- a/openedx2zim/xblocks_extractor/base_xblock.py
+++ b/openedx2zim/xblocks_extractor/base_xblock.py
@@ -1,3 +1,4 @@
+from multiprocessing import Lock
 from slugify import slugify
 
 from ..constants import getLogger
@@ -18,6 +19,8 @@ class BaseXblock:
     watcher = ExtractionWatcher()
     watcher_min_dl_count = 0
     watcher_min_ratio = 0
+
+    lock = Lock()
 
     def __init__(
         self, xblock_json, output_path, root_url, xblock_id, descendants, scraper
@@ -41,10 +44,9 @@ class BaseXblock:
     def too_many_failures(cls):
         return cls.watcher.dl_count > cls.watcher_min_dl_count and (cls.watcher.success_count / cls.watcher.dl_count) < cls.watcher_min_ratio
     
-    def download(self, instance_connection, lock):
+    def download(self, instance_connection):
         if BaseXblock.too_many_failures():
             return
-        self.lock = lock
         with self.lock:
             self.watcher.dl_count += 1
         logger.debug(f"Downloading resource {self.watcher.dl_count} of {self.watcher.total_count} ({self.watcher.success_count} success so far)")

--- a/openedx2zim/xblocks_extractor/base_xblock.py
+++ b/openedx2zim/xblocks_extractor/base_xblock.py
@@ -1,7 +1,24 @@
 from slugify import slugify
 
+from ..constants import getLogger
+
+
+class ExtractionWatcher:
+    total_count = 0
+    dl_count = 0
+    success_count = 0
+    failed_xblocks = []
+
+
+logger = getLogger()
+
 
 class BaseXblock:
+
+    watcher = ExtractionWatcher()
+    watcher_min_dl_count = 0
+    watcher_min_ratio = 0
+
     def __init__(
         self, xblock_json, output_path, root_url, xblock_id, descendants, scraper
     ):
@@ -18,7 +35,34 @@ class BaseXblock:
         # make xblock output directory
         self.output_path.mkdir(parents=True, exist_ok=True)
 
-    def download(self, instance_connection):
+        self.watcher.total_count += 1
+
+    @classmethod
+    def too_many_failures(cls):
+        return cls.watcher.dl_count > cls.watcher_min_dl_count and (cls.watcher.success_count / cls.watcher.dl_count) < cls.watcher_min_ratio
+    
+    def download(self, instance_connection, lock):
+        if BaseXblock.too_many_failures():
+            return
+        self.lock = lock
+        with self.lock:
+            self.watcher.dl_count += 1
+        logger.debug(f"Downloading resource {self.watcher.dl_count} of {self.watcher.total_count} ({self.watcher.success_count} success so far)")
+        try:
+            self.download_inner(instance_connection=instance_connection)
+        except Exception:
+            self.add_failed({})
+            return
+        with self.lock:
+            self.watcher.success_count += 1
+
+    def add_failed(self, description):
+        with self.lock:
+            description["xblock_id"] = self.xblock_id
+            description["class"] = type(self).__name__
+            self.watcher.failed_xblocks.append(description)
+
+    def download_inner(self, instance_connection):
         return
 
     def render(self):

--- a/openedx2zim/xblocks_extractor/discussion.py
+++ b/openedx2zim/xblocks_extractor/discussion.py
@@ -78,8 +78,6 @@ class Discussion(BaseXblock):
             try:
                 content = instance_connection.get_page(url)
             except Exception:
-                content = None
-            if not content:
                 self.add_failed({"url": url})
                 return
             soup = BeautifulSoup(content, "lxml")

--- a/openedx2zim/xblocks_extractor/discussion.py
+++ b/openedx2zim/xblocks_extractor/discussion.py
@@ -72,10 +72,15 @@ class Discussion(BaseXblock):
                     )
                 )
 
-    def download(self, instance_connection):
+    def download_inner(self, instance_connection):
         if self.scraper.forum:
-            content = instance_connection.get_page(self.xblock_json["student_view_url"])
+            url = self.xblock_json["student_view_url"]
+            try:
+                content = instance_connection.get_page(url)
+            except Exception:
+                content = None
             if not content:
+                self.add_failed({"url": url})
                 return
             soup = BeautifulSoup(content, "lxml")
 

--- a/openedx2zim/xblocks_extractor/drag_and_drop_v2.py
+++ b/openedx2zim/xblocks_extractor/drag_and_drop_v2.py
@@ -25,8 +25,6 @@ class DragAndDropV2(
         try:
             content = instance_connection.get_page(url)
         except Exception:
-            content = None
-        if not content:
             self.add_failed({"url": url})
             return
         soup = BeautifulSoup(content, "lxml")

--- a/openedx2zim/xblocks_extractor/drag_and_drop_v2.py
+++ b/openedx2zim/xblocks_extractor/drag_and_drop_v2.py
@@ -20,9 +20,14 @@ class DragAndDropV2(
         # extra vars
         self.content = None
 
-    def download(self, instance_connection):
-        content = instance_connection.get_page(self.xblock_json["student_view_url"])
+    def download_inner(self, instance_connection):
+        url = self.xblock_json["student_view_url"]
+        try:
+            content = instance_connection.get_page(url)
+        except Exception:
+            content = None
         if not content:
+            self.add_failed({"url": url})
             return
         soup = BeautifulSoup(content, "lxml")
         self.content = json.loads(

--- a/openedx2zim/xblocks_extractor/free_text_response.py
+++ b/openedx2zim/xblocks_extractor/free_text_response.py
@@ -15,9 +15,14 @@ class FreeTextResponse(BaseXblock):
         # extra vars
         self.html = ""
 
-    def download(self, instance_connection):
-        content = instance_connection.get_page(self.xblock_json["student_view_url"])
+    def download_inner(self, instance_connection):
+        url = self.xblock_json["student_view_url"]
+        try:
+            content = instance_connection.get_page(url)
+        except Exception:
+            content = None
         if not content:
+            self.add_failed({"url": url})
             return
         soup = BeautifulSoup(content, "lxml")
         html_content = soup.find("div", attrs={"class": "edx-notes-wrapper"})

--- a/openedx2zim/xblocks_extractor/free_text_response.py
+++ b/openedx2zim/xblocks_extractor/free_text_response.py
@@ -20,8 +20,6 @@ class FreeTextResponse(BaseXblock):
         try:
             content = instance_connection.get_page(url)
         except Exception:
-            content = None
-        if not content:
             self.add_failed({"url": url})
             return
         soup = BeautifulSoup(content, "lxml")

--- a/openedx2zim/xblocks_extractor/html.py
+++ b/openedx2zim/xblocks_extractor/html.py
@@ -15,9 +15,14 @@ class Html(BaseXblock):
         self.is_video = False  # check this
         self.html = ""
 
-    def download(self, instance_connection):
-        content = instance_connection.get_page(self.xblock_json["student_view_url"])
+    def download_inner(self, instance_connection):
+        url = self.xblock_json["student_view_url"]
+        try:
+            content = instance_connection.get_page(url)
+        except Exception:
+            content = None
         if not content:
+            self.add_failed({"url": url})
             return
         soup = BeautifulSoup(content, "lxml")
         html_content = soup.find("div", attrs={"class": "xblock"})

--- a/openedx2zim/xblocks_extractor/html.py
+++ b/openedx2zim/xblocks_extractor/html.py
@@ -20,8 +20,6 @@ class Html(BaseXblock):
         try:
             content = instance_connection.get_page(url)
         except Exception:
-            content = None
-        if not content:
             self.add_failed({"url": url})
             return
         soup = BeautifulSoup(content, "lxml")

--- a/openedx2zim/xblocks_extractor/libcast.py
+++ b/openedx2zim/xblocks_extractor/libcast.py
@@ -20,8 +20,6 @@ class Libcast(BaseXblock):
         try:
             content = instance_connection.get_page(url)
         except Exception:
-            content = None
-        if not content:
             self.add_failed({"url": url})
             return
         soup = BeautifulSoup(content, "lxml")

--- a/openedx2zim/xblocks_extractor/libcast.py
+++ b/openedx2zim/xblocks_extractor/libcast.py
@@ -50,8 +50,7 @@ class Libcast(BaseXblock):
             video_path = self.output_path.joinpath("video.mp4")
         if not video_path.exists():
             prepared_url = prepare_url(url, self.scraper.instance_url)
-            success = self.scraper.download_file(prepared_url, video_path)
-            if not success:
+            if not self.scraper.download_file(prepared_url, video_path):
                 self.add_failed({"url": prepared_url})
 
     def render(self):

--- a/openedx2zim/xblocks_extractor/libcast.py
+++ b/openedx2zim/xblocks_extractor/libcast.py
@@ -15,9 +15,14 @@ class Libcast(BaseXblock):
         # extra vars
         self.subs = []
 
-    def download(self, instance_connection):
-        content = instance_connection.get_page(self.xblock_json["student_view_url"])
+    def download_inner(self, instance_connection):
+        url = self.xblock_json["student_view_url"]
+        try:
+            content = instance_connection.get_page(url)
+        except Exception:
+            content = None
         if not content:
+            self.add_failed({"url": url})
             return
         soup = BeautifulSoup(content, "lxml")
         url = str(soup.find("video").find("source")["src"])
@@ -44,9 +49,10 @@ class Libcast(BaseXblock):
         else:
             video_path = self.output_path.joinpath("video.mp4")
         if not video_path.exists():
-            self.scraper.download_file(
-                prepare_url(url, self.scraper.instance_url), video_path
-            )
+            prepared_url = prepare_url(url, self.scraper.instance_url)
+            success = self.scraper.download_file(prepared_url, video_path)
+            if not success:
+                self.add_failed({"url": prepared_url})
 
     def render(self):
         return jinja(

--- a/openedx2zim/xblocks_extractor/lti.py
+++ b/openedx2zim/xblocks_extractor/lti.py
@@ -13,14 +13,18 @@ class Lti(BaseXblock):
             xblock_json, relative_path, root_url, xblock_id, descendants, scraper
         )
 
-    def download(self, instance_connection):
+    def download_inner(self, instance_connection):
         # IMPROUVEMENT LTI can be lot of content type ? Here pdf
         url = (
             self.xblock_json["lms_web_url"].replace("/jump_to/", "/xblock/")
             + "/handler/preview_handler"
         )
-        content = instance_connection.get_page(url)
+        try:
+            content = instance_connection.get_page(url)
+        except Exception:
+            content = None
         if not content:
+            self.add_failed({"url": url})
             return
         soup = BeautifulSoup(content, "lxml")
         content_url = soup.find("form")

--- a/openedx2zim/xblocks_extractor/lti.py
+++ b/openedx2zim/xblocks_extractor/lti.py
@@ -22,8 +22,6 @@ class Lti(BaseXblock):
         try:
             content = instance_connection.get_page(url)
         except Exception:
-            content = None
-        if not content:
             self.add_failed({"url": url})
             return
         soup = BeautifulSoup(content, "lxml")

--- a/openedx2zim/xblocks_extractor/problem.py
+++ b/openedx2zim/xblocks_extractor/problem.py
@@ -208,8 +208,6 @@ class Problem(BaseXblock):
         try:
             content = instance_connection.get_page(url)
         except Exception:
-            content = None
-        if not content:
             self.add_failed({"url": url})
             return
         raw_soup = BeautifulSoup(content, "lxml")

--- a/openedx2zim/xblocks_extractor/problem.py
+++ b/openedx2zim/xblocks_extractor/problem.py
@@ -200,12 +200,17 @@ class Problem(BaseXblock):
         for span in soup.find_all("span", attrs={"class": "sr"}):
             span.decompose()
 
-    def download(self, instance_connection):
+    def download_inner(self, instance_connection):
         """ download the problem xblock content from the instance """
 
         # try to fetch content
-        content = instance_connection.get_page(self.xblock_json["student_view_url"])
+        url = self.xblock_json["student_view_url"]
+        try:
+            content = instance_connection.get_page(url)
+        except Exception:
+            content = None
         if not content:
+            self.add_failed({"url": url})
             return
         raw_soup = BeautifulSoup(content, "lxml")
         self.xmodule_handler = str(

--- a/openedx2zim/xblocks_extractor/vertical.py
+++ b/openedx2zim/xblocks_extractor/vertical.py
@@ -33,9 +33,8 @@ class Vertical(BaseXblock):
         try:
             content = instance_connection.get_page(url)
         except Exception:
-            content = None
-        if not content:
             self.add_failed({"url": url})
+            return
         soup = BeautifulSoup(content, "lxml")
 
         # extract CSS and JS from HTML head

--- a/openedx2zim/xblocks_extractor/vertical.py
+++ b/openedx2zim/xblocks_extractor/vertical.py
@@ -27,9 +27,15 @@ class Vertical(BaseXblock):
         else:
             self.icon_type = "fa-book"
 
-    def download(self, instance_connection):
+    def download_inner(self, instance_connection):
         # get the LMS content for the vertical
-        content = instance_connection.get_page(self.xblock_json["lms_web_url"])
+        url = self.xblock_json["lms_web_url"]
+        try:
+            content = instance_connection.get_page(url)
+        except Exception:
+            content = None
+        if not content:
+            self.add_failed({"url": url})
         soup = BeautifulSoup(content, "lxml")
 
         # extract CSS and JS from HTML head

--- a/openedx2zim/xblocks_extractor/video.py
+++ b/openedx2zim/xblocks_extractor/video.py
@@ -43,8 +43,6 @@ class Video(BaseXblock):
         try:
             content = instance_connection.get_page(url)
         except Exception:
-            content = None
-        if not content:
             self.add_failed({"url": url})
             return False
         soup = BeautifulSoup.BeautifulSoup(content, "lxml")
@@ -95,8 +93,6 @@ class Video(BaseXblock):
             try:
                 content = instance_connection.get_page(url)
             except Exception:
-                content = None
-            if not content:
                 self.add_failed({"url": url})
                 return False
             soup = BeautifulSoup.BeautifulSoup(content, "lxml")

--- a/openedx2zim/xblocks_extractor/video.py
+++ b/openedx2zim/xblocks_extractor/video.py
@@ -23,106 +23,135 @@ class Video(BaseXblock):
         # extra vars
         self.subs = []
 
-    def download(self, instance_connection):
-        subs_lang = {}
-        youtube = False
-        if "student_view_data" not in self.xblock_json:
-            content = instance_connection.get_page(self.xblock_json["student_view_url"])
-            if not content:
-                return
-            soup = BeautifulSoup.BeautifulSoup(content, "lxml")
-            url = str(soup.find("video").find("source")["src"])
-            subs = soup.find("video").find_all("track")
-            subs_lang = {}
-            if len(subs) != 0:
-                for track in subs:
-                    if track["src"][0:4] == "http":
-                        subs_lang[track["srclang"]] = track["src"]
-                    else:
-                        subs_lang[track["srclang"]] = (
-                            self.scraper.instance_url + track["src"]
-                        )
-        else:
-            if (
-                "fallback" in self.xblock_json["student_view_data"]["encoded_videos"]
-                and "url"
-                in self.xblock_json["student_view_data"]["encoded_videos"]["fallback"]
-            ):
-                url = urllib.parse.unquote(
-                    self.xblock_json["student_view_data"]["encoded_videos"]["fallback"][
-                        "url"
-                    ]
-                )
-            elif (
-                "mobile_low" in self.xblock_json["student_view_data"]["encoded_videos"]
-                and "url"
-                in self.xblock_json["student_view_data"]["encoded_videos"]["mobile_low"]
-            ):
-                url = urllib.parse.unquote(
-                    self.xblock_json["student_view_data"]["encoded_videos"][
-                        "mobile_low"
-                    ]["url"]
-                )
-            elif (
-                "youtube" in self.xblock_json["student_view_data"]["encoded_videos"]
-                and "url"
-                in self.xblock_json["student_view_data"]["encoded_videos"]["youtube"]
-            ):
-                url = self.xblock_json["student_view_data"]["encoded_videos"][
-                    "youtube"
-                ]["url"]
-                youtube = True
-            else:
-                content = instance_connection.get_page(
-                    self.xblock_json["student_view_url"]
-                )
-                if not content:
-                    return
-                soup = BeautifulSoup.BeautifulSoup(content, "lxml")
-                youtube_json = soup.find("div", attrs={"id": re.compile("^video_")})
-                if youtube_json and youtube_json.has_attr("data-metadata"):
-                    youtube_json = json.loads(youtube_json["data-metadata"])
-                    url = (
-                        "https://www.youtube.com/watch?v="
-                        + youtube_json["streams"].split(":")[-1]
-                    )
-                    youtube = True
-                    if (
-                        "transcriptTranslationUrl" in youtube_json
-                        and "transcriptLanguages" in youtube_json
-                    ):
-                        for lang in youtube_json["transcriptLanguages"]:
-                            subs_lang[lang] = instance_connection.conf[
-                                "instance_url"
-                            ] + youtube_json["transcriptTranslationUrl"].replace(
-                                "__lang__", lang
-                            )
-                else:
-                    self.no_video = True
-                    logger.error(
-                        "Cannot get video for {}".format(
-                            self.xblock_json["lms_web_url"]
-                        )
-                    )
-                    logger.error(self.xblock_json)
-                    return
-            if subs_lang == {}:
-                subs_lang = self.xblock_json["student_view_data"]["transcripts"]
+    def download_inner(self, instance_connection):
+        self.subs_lang = {}
+        self.youtube = False
 
+        if not self.prepare_download(instance_connection):
+            return
+
+        self.download_video(instance_connection)
+
+    def prepare_download(self, instance_connection):
+        if "student_view_data" not in self.xblock_json:
+            return self.prepare_download_view_url(instance_connection)
+        else:
+            return self.prepare_download_view_data(instance_connection)
+
+    def prepare_download_view_url(self, instance_connection):
+        url = self.xblock_json["student_view_url"]
+        try:
+            content = instance_connection.get_page(url)
+        except Exception:
+            content = None
+        if not content:
+            self.add_failed({"url": url})
+            return False
+        soup = BeautifulSoup.BeautifulSoup(content, "lxml")
+        self.url = str(soup.find("video").find("source")["src"])
+        subs = soup.find("video").find_all("track")
+        if len(subs) != 0:
+            for track in subs:
+                if track["src"][0:4] == "http":
+                    self.subs_lang[track["srclang"]] = track["src"]
+                else:
+                    self.subs_lang[track["srclang"]] = (
+                        self.scraper.instance_url + track["src"]
+                    )
+        return True
+
+    def prepare_download_view_data(self, instance_connection):
+        if (
+            "fallback" in self.xblock_json["student_view_data"]["encoded_videos"]
+            and "url"
+            in self.xblock_json["student_view_data"]["encoded_videos"]["fallback"]
+        ):
+            self.url = urllib.parse.unquote(
+                self.xblock_json["student_view_data"]["encoded_videos"]["fallback"][
+                    "url"
+                ]
+            )
+        elif (
+            "mobile_low" in self.xblock_json["student_view_data"]["encoded_videos"]
+            and "url"
+            in self.xblock_json["student_view_data"]["encoded_videos"]["mobile_low"]
+        ):
+            self.url = urllib.parse.unquote(
+                self.xblock_json["student_view_data"]["encoded_videos"][
+                    "mobile_low"
+                ]["url"]
+            )
+        elif (
+            "youtube" in self.xblock_json["student_view_data"]["encoded_videos"]
+            and "url"
+            in self.xblock_json["student_view_data"]["encoded_videos"]["youtube"]
+        ):
+            self.url = self.xblock_json["student_view_data"]["encoded_videos"][
+                "youtube"
+            ]["url"]
+            self.youtube = True
+        else:
+            url = self.xblock_json["student_view_url"]
+            try:
+                content = instance_connection.get_page(url)
+            except Exception:
+                content = None
+            if not content:
+                self.add_failed({"url": url})
+                return False
+            soup = BeautifulSoup.BeautifulSoup(content, "lxml")
+            youtube_json = soup.find("div", attrs={"id": re.compile("^video_")})
+            if youtube_json and youtube_json.has_attr("data-metadata"):
+                youtube_json = json.loads(youtube_json["data-metadata"])
+                url = (
+                    "https://www.youtube.com/watch?v="
+                    + youtube_json["streams"].split(":")[-1]
+                )
+                self.youtube = True
+                if (
+                    "transcriptTranslationUrl" in youtube_json
+                    and "transcriptLanguages" in youtube_json
+                ):
+                    for lang in youtube_json["transcriptLanguages"]:
+                        self.subs_lang[lang] = instance_connection.conf[
+                            "instance_url"
+                        ] + youtube_json["transcriptTranslationUrl"].replace(
+                            "__lang__", lang
+                        )
+            else:
+                self.no_video = True
+                logger.error(
+                    "Cannot get video for {}".format(
+                        self.xblock_json["lms_web_url"]
+                    )
+                )
+                logger.error(self.xblock_json)
+                self.add_failed({"url": self.xblock_json["lms_web_url"]})
+                return False
+        if self.subs_lang == {}:
+            self.subs_lang = self.xblock_json["student_view_data"]["transcripts"]
+        return True
+
+    def download_video(self, instance_connection):
         if self.scraper.video_format == "webm":
             video_path = self.output_path.joinpath("video.webm")
         else:
             video_path = self.output_path.joinpath("video.mp4")
         if not video_path.exists():
-            if youtube:
-                self.scraper.download_file(url, video_path)
+            if self.youtube:
+                success = self.scraper.download_file(self.url, video_path)
+                if not success:
+                    self.add_failed({"url": self.url})
             else:
-                self.scraper.download_file(
-                    prepare_url(urllib.parse.unquote(url), self.scraper.instance_url),
+                prepared_url = prepare_url(urllib.parse.unquote(self.url), self.scraper.instance_url)
+                success = self.scraper.download_file(
+                    prepared_url,
                     video_path,
                 )
+                if not success:
+                    self.add_failed({"url": prepared_url})
         real_subtitle = download_and_convert_subtitles(
-            self.output_path, subs_lang, instance_connection
+            self.output_path, self.subs_lang, instance_connection
         )
         self.subs = [
             {"file": f"{self.folder_name}/{lang}.vtt", "code": lang}


### PR DESCRIPTION
## Rationale 
Fix #160 

## Changes
- scraper will fail when there are too many erros while retrieving xblocks

## Implementation details

- there is now a global watcher for all xblocks, with
  - `total_count`: the total number of xblocks to retrieve
  - `dl_count`: the total number of xblocks download attempt so far
  - `success_count`: the total number of xblocks successful download so far
  - `failed_xblocks`: details about failed xblocks

- there are two parameters to control scrapper stop:
  - `watcher_min_ratio`: the minimum ratio of successful downloads (compared to the number of download attempts)
  - `watcher_min_dl_count`: the minimum number of xblocks to have attempted to download before stopping the scraper (because otherwise the ratio might be wrong just because we are unlucky in terms of xblocks download order)

- these two parameters can be set at the CLI level

 