### PR TITLE
support_description_long_description

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ celerybeat-schedule
 
 # dotenv
 .env
+.venv
 
 # virtualenv
 venv/
@@ -92,3 +93,5 @@ openedx2zim/templates/assets/mathjax/
 openedx2zim/templates/assets/ogvjs/
 openedx2zim/templates/assets/jquery.min.js
 openedx2zim/templates/assets/videojs-ogvjs.js
+openedx/openedx2zim.egg-info/
+openedx/output/

--- a/openedx2zim/entrypoint.py
+++ b/openedx2zim/entrypoint.py
@@ -75,6 +75,13 @@ def main():
         help="Custom description for your ZIM. Based on MOOC otherwise.",
     )
 
+    ##made changes here 
+    parser.add_argument(
+        "--long-description",
+        help="Custom description for your ZIM,optional",
+    )
+
+
     parser.add_argument("--creator", help="Name of content creator", default="edX")
 
     parser.add_argument(

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Jinja2>=2.11.2,<2.12
 mistune>=2.0.0a4,<2.1
 requests>=2.24,<3.0
 iso-639>=0.4.5,<0.5
-zimscraperlib>=1.3.6,<1.4
+zimscraperlib
 kiwixstorage>=0.3,<1.0
 pif>=0.8.2,<0.9
 xxhash>=2.0.0,<2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Jinja2>=2.11.2,<2.12
 mistune>=2.0.0a4,<2.1
 requests>=2.24,<3.0
 iso-639>=0.4.5,<0.5
-zimscraperlib
+zimscraperlib==3.2.0
 kiwixstorage>=0.3,<1.0
 pif>=0.8.2,<0.9
 xxhash>=2.0.0,<2.1


### PR DESCRIPTION
Fix #181 

I have added a function called `handle_descriptions` that takes in three inputs: `default_description`, `description`, and `long_description`. It returns the description either as `long_description` or `description`. I have also made changes in the `get_zim_info` function.

Additionally, the newer version of `make_zim_file` does not take `favicon` as an input parameter, so I changed it to `illustrations`.

  